### PR TITLE
CA-547: feat: Add database schemas for companies and professional roles.

### DIFF
--- a/supabase/schemas/core/companies/01_table.sql
+++ b/supabase/schemas/core/companies/01_table.sql
@@ -1,0 +1,31 @@
+-- Companies Table
+-- Organizations that own projects and have team members
+
+CREATE TABLE IF NOT EXISTS "public"."companies" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "email" character varying(255) NOT NULL,
+    "phone" character varying(50) NOT NULL,
+    "name" character varying(255) NOT NULL,
+    "logo_url" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."companies" OWNER TO "postgres";
+
+
+-- Primary Key
+
+ALTER TABLE ONLY "public"."companies"
+    ADD CONSTRAINT "companies_pkey" PRIMARY KEY ("id");
+
+
+-- Unique Constraints
+
+ALTER TABLE ONLY "public"."companies"
+    ADD CONSTRAINT "companies_email_key" UNIQUE ("email");
+
+
+ALTER TABLE ONLY "public"."companies"
+    ADD CONSTRAINT "companies_phone_key" UNIQUE ("phone");

--- a/supabase/schemas/core/companies/02_indexes.sql
+++ b/supabase/schemas/core/companies/02_indexes.sql
@@ -1,0 +1,2 @@
+-- Companies Indexes
+-- No additional indexes defined beyond primary key and unique constraints

--- a/supabase/schemas/core/companies/03_rls.sql
+++ b/supabase/schemas/core/companies/03_rls.sql
@@ -1,0 +1,3 @@
+-- Companies RLS Policies
+
+ALTER TABLE "public"."companies" ENABLE ROW LEVEL SECURITY;

--- a/supabase/schemas/core/companies/03_rls.sql
+++ b/supabase/schemas/core/companies/03_rls.sql
@@ -1,3 +1,8 @@
 -- Companies RLS Policies
 
+-- TODO: [CA-711] Add permissive RLS policies for companies once
+-- company-level permission helpers are confirmed.
+-- https://ripplearc.youtrack.cloud/issue/CA-711
+-- RLS is intentionally enabled here to enforce default-deny in the interim.
+
 ALTER TABLE "public"."companies" ENABLE ROW LEVEL SECURITY;

--- a/supabase/schemas/core/companies/04_triggers.sql
+++ b/supabase/schemas/core/companies/04_triggers.sql
@@ -1,0 +1,8 @@
+-- Companies Triggers
+
+-- Update Timestamp
+-- Automatically updates updated_at column on row modification
+CREATE OR REPLACE TRIGGER "trigger_update_companies_updated_at"
+    BEFORE UPDATE ON "public"."companies"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."set_current_timestamp_updated_at"();

--- a/supabase/schemas/core/companies/README.md
+++ b/supabase/schemas/core/companies/README.md
@@ -1,0 +1,240 @@
+# Companies Module
+
+## Overview
+
+The `companies` table stores organization information. Companies can own projects, have teams, and employ users through the `company_users` relationship.
+
+## Table Structure
+
+### Core Fields
+- `id` - UUID primary key
+- `name` - Company name
+- `email` - Company contact email (unique)
+- `phone` - Company contact phone (unique)
+- `logo_url` - URL to company logo image
+
+### Metadata
+- `created_at` - Company creation timestamp
+- `updated_at` - Last update timestamp
+
+## Business Rules
+
+### 1. Contact Information Uniqueness
+- Email must be unique across all companies
+- Phone must be unique across all companies
+- Both are required (not nullable)
+
+This ensures:
+- No duplicate company registrations
+- Clear contact points per organization
+- Easy lookup by email or phone
+
+### 2. Company Hierarchy
+Companies are the top-level organizational unit:
+```
+Company
+├── Teams (via teams table)
+│   └── Team Members (users)
+├── Company Users (via company_users)
+│   └── Users with roles
+└── Projects (via projects.owning_company_id)
+```
+
+### 3. Logo Management
+- `logo_url` is optional
+- Should point to image storage (e.g., S3)
+- Logo should be displayed in company branding
+- Consider size/format restrictions in application
+
+## Indexes
+
+No additional indexes beyond:
+- Primary key on `id`
+- Unique constraint on `email`
+- Unique constraint on `phone`
+
+These are sufficient for typical queries (lookup by ID, email, or phone).
+
+## RLS Policies
+
+RLS is enabled but no specific policies are defined in this extraction.
+
+Typical policies to consider:
+- **SELECT**: Users can view companies they belong to
+- **INSERT**: Admins/system can create companies
+- **UPDATE**: Company admins can update their company
+- **DELETE**: System admins can delete companies
+
+Example policy (not currently implemented):
+```sql
+-- Users can view companies they're members of
+CREATE POLICY "view_own_company" ON companies
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM company_users
+      WHERE company_users.company_id = companies.id
+        AND company_users.user_id = (
+          SELECT id FROM users WHERE credential_id = auth.uid()
+        )
+    )
+  );
+```
+
+## Usage Examples
+
+### Creating a Company
+```sql
+INSERT INTO companies (
+  name,
+  email,
+  phone,
+  logo_url
+) VALUES (
+  'Acme Construction',
+  'info@acmeconstruction.com',
+  '+1-555-0123',
+  'https://storage.example.com/logos/acme.png'
+);
+```
+
+### Updating Company Info
+```sql
+UPDATE companies
+SET
+  name = 'Acme Construction Inc.',
+  logo_url = 'https://storage.example.com/logos/acme_new.png',
+  updated_at = now()
+WHERE id = 'company-uuid';
+```
+
+### Finding Company by Email
+```sql
+SELECT *
+FROM companies
+WHERE email = 'info@acmeconstruction.com';
+```
+
+### Getting All Users in a Company
+```sql
+SELECT
+  u.id,
+  u.first_name,
+  u.last_name,
+  u.email,
+  r.role_name
+FROM companies c
+JOIN company_users cu ON c.id = cu.company_id
+JOIN users u ON cu.user_id = u.id
+JOIN roles r ON cu.role_id = r.id
+WHERE c.id = 'company-uuid';
+```
+
+### Getting All Teams in a Company
+```sql
+SELECT *
+FROM teams
+WHERE company_id = 'company-uuid'
+ORDER BY team_name;
+```
+
+### Getting Company Projects
+```sql
+SELECT *
+FROM projects
+WHERE owning_company_id = 'company-uuid'
+  AND project_status = 'active'
+ORDER BY created_at DESC;
+```
+
+## Related Tables
+
+### Direct References to Companies
+- `company_users` - Links users to companies with roles
+- `teams` - Teams within a company
+- `projects` - Projects owned by company (via owning_company_id)
+
+### Indirect Relationships
+- Through teams: `team_members`, `project_teams`
+- Through projects: All project-related data
+
+## Best Practices
+
+### Company Creation
+- Validate email format before insertion
+- Verify phone format (consider international formats)
+- Ensure name is not empty or just whitespace
+- Logo URL should be validated as valid URL
+
+### Email & Phone Management
+- Use lowercase for emails for consistency
+- Store phone in international format (+country-code)
+- Handle unique constraint violations gracefully
+
+### Logo Management
+- Store actual images in object storage (S3, etc.)
+- Only store URL in database
+- Consider image size limits (recommend 500x500px or similar)
+- Support common formats (PNG, JPG, SVG)
+
+### Data Integrity
+- Before deleting company, consider:
+  - Existing projects
+  - Current team members
+  - Active company users
+- Consider "soft delete" approach instead
+- Or cascade delete carefully
+
+## Common Queries
+
+### Active Companies with User Count
+```sql
+SELECT
+  c.id,
+  c.name,
+  c.email,
+  COUNT(cu.user_id) as user_count
+FROM companies c
+LEFT JOIN company_users cu ON c.id = cu.company_id
+GROUP BY c.id, c.name, c.email
+ORDER BY user_count DESC;
+```
+
+### Companies with Project Count
+```sql
+SELECT
+  c.id,
+  c.name,
+  COUNT(p.id) as project_count
+FROM companies c
+LEFT JOIN projects p ON c.id = p.owning_company_id
+GROUP BY c.id, c.name
+ORDER BY project_count DESC;
+```
+
+### Company Admin Users
+```sql
+-- Assuming there's a 'Company Admin' role
+SELECT
+  c.name as company_name,
+  u.first_name,
+  u.last_name,
+  u.email
+FROM companies c
+JOIN company_users cu ON c.id = cu.company_id
+JOIN users u ON cu.user_id = u.id
+JOIN roles r ON cu.role_id = r.id
+WHERE r.role_name = 'Company Admin'
+  AND c.id = 'company-uuid';
+```
+
+## Testing
+
+No specific test files exist yet for companies table.
+
+Consider testing:
+- Unique constraint on email
+- Unique constraint on phone
+- Company creation workflow
+- Company-user relationships
+- Company-project relationships

--- a/supabase/schemas/core/companies/README.md
+++ b/supabase/schemas/core/companies/README.md
@@ -103,8 +103,8 @@ INSERT INTO companies (
 UPDATE companies
 SET
   name = 'Acme Construction Inc.',
-  logo_url = 'https://storage.example.com/logos/acme_new.png',
-  updated_at = now()
+  logo_url = 'https://storage.example.com/logos/acme_new.png'
+  -- updated_at is set automatically by trigger
 WHERE id = 'company-uuid';
 ```
 

--- a/supabase/schemas/core/professional_roles/01_table.sql
+++ b/supabase/schemas/core/professional_roles/01_table.sql
@@ -1,0 +1,24 @@
+-- Professional Roles Table
+-- Defines available professional roles/occupations for users
+
+CREATE TABLE IF NOT EXISTS "public"."professional_roles" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "name" character varying(255) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."professional_roles" OWNER TO "postgres";
+
+
+-- Primary Key
+
+ALTER TABLE ONLY "public"."professional_roles"
+    ADD CONSTRAINT "professional_roles_pkey" PRIMARY KEY ("id");
+
+
+-- Unique Constraints
+
+ALTER TABLE ONLY "public"."professional_roles"
+    ADD CONSTRAINT "professional_roles_name_key" UNIQUE ("name");

--- a/supabase/schemas/core/professional_roles/02_indexes.sql
+++ b/supabase/schemas/core/professional_roles/02_indexes.sql
@@ -1,0 +1,2 @@
+-- Professional Roles Indexes
+-- No additional indexes defined beyond primary key and unique constraint

--- a/supabase/schemas/core/professional_roles/03_rls.sql
+++ b/supabase/schemas/core/professional_roles/03_rls.sql
@@ -1,0 +1,9 @@
+-- Professional Roles RLS Policies
+
+ALTER TABLE "public"."professional_roles" ENABLE ROW LEVEL SECURITY;
+
+
+-- Public SELECT Policy
+-- Anyone can view available professional roles
+
+CREATE POLICY "professional_roles_select_public" ON "public"."professional_roles" FOR SELECT USING (true);

--- a/supabase/schemas/core/professional_roles/03_rls.sql
+++ b/supabase/schemas/core/professional_roles/03_rls.sql
@@ -7,3 +7,8 @@ ALTER TABLE "public"."professional_roles" ENABLE ROW LEVEL SECURITY;
 -- Anyone can view available professional roles
 
 CREATE POLICY "professional_roles_select_public" ON "public"."professional_roles" FOR SELECT USING (true);
+
+-- No INSERT/UPDATE/DELETE policies defined.
+-- Write access is intentionally restricted to service_role / migrations only.
+-- Reference data is managed via seed files (supabase/seeders/sample_data/101_professional_roles.sql),
+-- not direct user writes.

--- a/supabase/schemas/core/professional_roles/04_triggers.sql
+++ b/supabase/schemas/core/professional_roles/04_triggers.sql
@@ -1,0 +1,8 @@
+-- Professional Roles Triggers
+
+-- Update Timestamp
+-- Automatically updates updated_at column on row modification
+CREATE OR REPLACE TRIGGER "trigger_update_professional_roles_updated_at"
+    BEFORE UPDATE ON "public"."professional_roles"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."set_current_timestamp_updated_at"();

--- a/supabase/schemas/core/professional_roles/README.md
+++ b/supabase/schemas/core/professional_roles/README.md
@@ -1,0 +1,220 @@
+# Professional Roles Module
+
+## Overview
+
+The `professional_roles` table is a lookup/reference table that defines available professional roles or occupations for users. Examples include "General Contractor", "Architect", "Project Manager", etc.
+
+## Table Structure
+
+### Core Fields
+- `id` - UUID primary key
+- `name` - Role name (unique)
+
+### Metadata
+- `created_at` - Role creation timestamp
+- `updated_at` - Last update timestamp
+
+## Business Rules
+
+### 1. Role Name Uniqueness
+- Each role name must be unique
+- Prevents duplicate role definitions
+- Names should be in title case (e.g., "General Contractor", not "general contractor")
+
+### 2. Reference Data
+This is a **reference/lookup table**:
+- Relatively static data (doesn't change frequently)
+- Seeded during database initialization
+- Used for dropdowns, filters, and categorization
+- Should not be user-editable in most cases
+
+### 3. Immutability Considerations
+Once a role is assigned to users:
+- Deleting it would orphan user records (FK constraint prevents this)
+- Renaming should be done carefully
+- Consider adding new roles instead of modifying existing ones
+
+## Indexes
+
+No additional indexes beyond:
+- Primary key on `id`
+- Unique constraint on `name`
+
+Sufficient for:
+- Lookup by ID (used in users.professional_role FK)
+- Lookup by name (for display, dropdowns)
+- Small table size makes full scans acceptable
+
+## RLS Policies
+
+### Public SELECT Policy
+**Name**: `professional_roles_select_public`
+
+**Rule**: `USING (true)`
+
+**Behavior**:
+- Anyone (including unauthenticated users) can view all roles
+- Needed for signup flow (user selects their role)
+- No sensitive data in this table
+
+**Other Operations**:
+- INSERT/UPDATE/DELETE not permitted via RLS
+- Should only be done via migrations or admin functions
+- Maintains data integrity
+
+## Usage Examples
+
+### Viewing All Available Roles
+```sql
+SELECT id, name
+FROM professional_roles
+ORDER BY name;
+```
+
+### Getting a Specific Role
+```sql
+SELECT *
+FROM professional_roles
+WHERE name = 'General Contractor';
+```
+
+### Using in User Signup
+```sql
+-- First, get available roles for dropdown
+SELECT id, name
+FROM professional_roles
+ORDER BY name;
+
+-- Then, create user with selected role
+INSERT INTO users (
+  credential_id,
+  email,
+  first_name,
+  last_name,
+  professional_role,
+  user_preferences
+) VALUES (
+  auth.uid(),
+  'user@example.com',
+  'John',
+  'Doe',
+  'role-uuid-from-dropdown',
+  '{}'::jsonb
+);
+```
+
+### Counting Users per Role
+```sql
+SELECT
+  pr.name as role_name,
+  COUNT(u.id) as user_count
+FROM professional_roles pr
+LEFT JOIN users u ON pr.id = u.professional_role
+GROUP BY pr.id, pr.name
+ORDER BY user_count DESC;
+```
+
+### Finding Users by Role
+```sql
+SELECT
+  u.id,
+  u.first_name,
+  u.last_name,
+  u.email
+FROM users u
+JOIN professional_roles pr ON u.professional_role = pr.id
+WHERE pr.name = 'Architect'
+ORDER BY u.last_name, u.first_name;
+```
+
+## Common Professional Roles
+
+Typical roles in construction/project management:
+
+- **General Contractor**
+- **Architect**
+- **Project Manager**
+- **Structural Engineer**
+- **Electrical Engineer**
+- **Plumber**
+- **Carpenter**
+- **Estimator**
+- **Superintendent**
+- **Safety Officer**
+- **Quantity Surveyor**
+- **Interior Designer**
+- **Civil Engineer**
+- **HVAC Technician**
+- **Developer**
+- **Owner/Client**
+
+These should be seeded during initial setup.
+
+## Related Tables
+
+### Tables Referencing Professional Roles
+- `users` - Each user has one professional_role
+
+## Seeding Data
+
+Professional roles should be seeded in migrations or seed files:
+
+```sql
+-- Example seed data
+INSERT INTO professional_roles (name) VALUES
+  ('General Contractor'),
+  ('Architect'),
+  ('Project Manager'),
+  ('Structural Engineer'),
+  ('Electrical Engineer'),
+  ('Plumber'),
+  ('Carpenter'),
+  ('Estimator'),
+  ('Superintendent'),
+  ('Safety Officer')
+ON CONFLICT (name) DO NOTHING;
+```
+
+See: `supabase/seeders/sample_data/101_professional_roles.sql`
+
+## Best Practices
+
+### Data Management
+- Seed roles during database initialization
+- Add new roles via migrations (not manual SQL)
+- Don't delete roles that have users assigned
+- Consider archiving unused roles instead of deleting
+
+### Naming Conventions
+- Use singular form ("Architect" not "Architects")
+- Use title case ("Project Manager" not "project manager")
+- Be specific but concise
+- Avoid abbreviations unless industry-standard
+
+### Application Integration
+- Cache roles in application (they rarely change)
+- Show roles alphabetically in dropdowns
+- Consider role grouping for large lists (e.g., "Engineering", "Trades")
+- Allow "Other" option if needed
+
+### Extensibility
+Consider adding fields in future:
+- `description` - Detailed role description
+- `category` - Group roles (e.g., "Engineering", "Management", "Trades")
+- `is_active` - Enable/disable roles without deleting
+- `display_order` - Custom ordering in dropdowns
+
+## Testing
+
+See: `supabase/seeders/sample_data/101_professional_roles.sql`
+
+Consider testing:
+- Unique constraint on name
+- Public SELECT access (unauthenticated)
+- No INSERT/UPDATE/DELETE via RLS
+- Foreign key relationship with users
+
+## Migration History
+
+- Initial creation in migration `20250514010731_02_professional_roles.sql`
+- RLS policy added in migration `20251203033508_RLS_05_public_tables_policies.sql`


### PR DESCRIPTION
# PR Review: feat/migrate-comapanies-and-project-roles → feat/migrate-user-feature-to-schema

### 1. PR SUMMARY
This PR migrates the `companies` and `professional_roles` feature into the schema-first approach under `supabase/schemas/core/`. It defines the core table structures, adds necessary unique constraints (email, phone, role name), sets up README documentation for both modules, and initializes default security configurations (RLS). 

### 2. REVIEW SUMMARY TABLE

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Default-Deny RLS on `companies` | RLS is enabled on `companies`, but no policies are defined. In Postgres, this creates a default-deny state, completely blocking all API access to the table. | | |
| Missing `updated_at` Triggers | Both `companies` and `professional_roles` tables have an `updated_at` field but no triggers are defined to automatically update them. | ✅ | |