### PR TITLE
feat: migrate cost estimates permissions to JWT-based authorization f…

### DIFF
--- a/docs/JWT-Auth.md
+++ b/docs/JWT-Auth.md
@@ -19,6 +19,7 @@ We will implement a Custom Access Token Hook that injects user permissions direc
 ```json
 {
   "app_metadata": {
+    "internal_user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "projects": {
       "550e8400-e29b-41d4-a716-446655440000": ["add_cost_estimation", "edit_cost_estimation", "get_cost_estimations"],
       "7c9e6679-7425-40de-944b-e07fc1f90ae7": ["get_cost_estimations", "lock_cost_estimation"]
@@ -27,7 +28,8 @@ We will implement a Custom Access Token Hook that injects user permissions direc
 }
 ```
 
-Each key is a `project_id` (UUID), and the value is an array of permission keys the user has for that project.
+- `internal_user_id`: The internal application user ID (`users.id`), used by triggers to set fields like `locked_by_user_id` without database lookups
+- `projects`: Each key is a `project_id` (UUID), and the value is an array of permission keys the user has for that project
 
 ### Benefits
 
@@ -54,8 +56,14 @@ AS $$
 DECLARE
   claims jsonb;
   projects_claims jsonb;
+  user_internal_id uuid;
 BEGIN
   claims := event->'claims';
+
+  -- Get the internal user ID (users.id) from credential_id
+  SELECT u.id INTO user_internal_id
+  FROM public.users u
+  WHERE u.credential_id = (event->>'user_id')::uuid;
 
   SELECT COALESCE(
     jsonb_object_agg(project_permissions.project_id, project_permissions.permissions),
@@ -75,10 +83,14 @@ BEGIN
     GROUP BY pm.project_id
   ) AS project_permissions;
 
+  -- Ensure app_metadata exists, then merge in projects and internal_user_id
   claims := jsonb_set(
     claims,
-    '{app_metadata,projects}',
-    projects_claims,
+    '{app_metadata}',
+    COALESCE(claims->'app_metadata', '{}'::jsonb) || jsonb_build_object(
+      'projects', projects_claims,
+      'internal_user_id', user_internal_id
+    ),
     true
   );
 

--- a/supabase/migrations/20260226000000_cost_estimate_activity_logging.sql
+++ b/supabase/migrations/20260226000000_cost_estimate_activity_logging.sql
@@ -78,27 +78,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_estimate_updated"() RETURNS "trigg
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_updated: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_updated: skipped logging for estimate %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_estimate_updated: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 
@@ -153,27 +143,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_estimate_deleted"() RETURNS "trigg
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_deleted: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_deleted: skipped logging for estimate %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_estimate_deleted: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 
@@ -234,27 +214,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_file_uploaded"() RETURNS "trigger"
 DECLARE
   v_user_id uuid;
   v_estimate_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_file_uploaded: skipped logging for file %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_file_uploaded: skipped logging for file %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_file_uploaded: skipped logging for file %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 
@@ -295,27 +265,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_file_deleted"() RETURNS "trigger"
 DECLARE
   v_user_id uuid;
   v_estimate_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_file_deleted: skipped logging for file %, no authenticated user (service role or migration context)', OLD.id;
-    RETURN OLD;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_file_deleted: skipped logging for file %, user not found for credential %', OLD.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_file_deleted: skipped logging for file %, no authenticated user (service role or migration context)', OLD.id;
     RETURN OLD;
   END IF;
 
@@ -375,27 +335,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_item_added"() RETURNS "trigger"
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_item_added: skipped logging for item %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_item_added: skipped logging for item %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_item_added: skipped logging for item %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 
@@ -427,30 +377,20 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_item_edited"() RETURNS "trigger"
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
   v_edited_fields jsonb;
   v_old_json jsonb;
   v_new_json jsonb;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_item_edited: skipped logging for item %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_item_edited: skipped logging for item %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_item_edited: skipped logging for item %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 
@@ -487,27 +427,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_item_removed"() RETURNS "trigger"
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_item_removed: skipped logging for item %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_item_removed: skipped logging for item %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_item_removed: skipped logging for item %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 

--- a/supabase/migrations/20260313081301_auth_hook_project_permission_claims.sql
+++ b/supabase/migrations/20260313081301_auth_hook_project_permission_claims.sql
@@ -8,8 +8,14 @@ AS $$
 DECLARE
   claims jsonb;
   projects_claims jsonb;
+  user_internal_id uuid;
 BEGIN
   claims := event->'claims';
+
+  -- Get the internal user ID (users.id) from credential_id
+  SELECT u.id INTO user_internal_id
+  FROM public.users u
+  WHERE u.credential_id = (event->>'user_id')::uuid;
 
   SELECT COALESCE(
     jsonb_object_agg(project_permissions.project_id, project_permissions.permissions),
@@ -29,12 +35,15 @@ BEGIN
     GROUP BY pm.project_id
   ) AS project_permissions;
 
-  -- Ensure app_metadata exists, then merge in projects
+  -- Ensure app_metadata exists, then merge in projects and internal_user_id
   -- This handles cases where claims don't yet have app_metadata (e.g., first login)
   claims := jsonb_set(
     claims,
     '{app_metadata}',
-    COALESCE(claims->'app_metadata', '{}'::jsonb) || jsonb_build_object('projects', projects_claims),
+    COALESCE(claims->'app_metadata', '{}'::jsonb) || jsonb_build_object(
+      'projects', projects_claims,
+      'internal_user_id', user_internal_id
+    ),
     true
   );
 

--- a/supabase/migrations/20260313081637_migrate_cost_estimates_rls_to_jwt.sql
+++ b/supabase/migrations/20260313081637_migrate_cost_estimates_rls_to_jwt.sql
@@ -34,6 +34,9 @@ CREATE POLICY "cost_estimates_update_policy" ON "cost_estimates"
   TO authenticated
   USING (
     jwt_has_project_permission(project_id, 'edit_cost_estimation')
+  )
+  WITH CHECK (
+    jwt_has_project_permission(project_id, 'edit_cost_estimation')
   );
 
 -- Policy for DELETE operations (removing cost estimates)

--- a/supabase/migrations/20260313081637_migrate_cost_estimates_rls_to_jwt.sql
+++ b/supabase/migrations/20260313081637_migrate_cost_estimates_rls_to_jwt.sql
@@ -1,0 +1,46 @@
+-- Migrate cost_estimates RLS policies to use JWT claims instead of database lookups
+-- This improves performance by reading permissions from JWT tokens rather than querying the database
+
+-- Drop existing RLS policies
+DROP POLICY IF EXISTS "cost_estimates_select_policy" ON "cost_estimates";
+DROP POLICY IF EXISTS "cost_estimates_insert_policy" ON "cost_estimates";
+DROP POLICY IF EXISTS "cost_estimates_update_policy" ON "cost_estimates";
+DROP POLICY IF EXISTS "cost_estimates_delete_policy" ON "cost_estimates";
+
+-- Create new JWT-based policies
+
+-- Policy for SELECT operations (viewing cost estimates)
+-- Users can view cost estimates if they have the 'get_cost_estimations' permission in their JWT
+CREATE POLICY "cost_estimates_select_policy" ON "cost_estimates"
+  FOR SELECT
+  TO authenticated
+  USING (
+    jwt_has_project_permission(project_id, 'get_cost_estimations')
+  );
+
+-- Policy for INSERT operations (creating cost estimates)
+-- Users can create cost estimates if they have the 'add_cost_estimation' permission in their JWT
+CREATE POLICY "cost_estimates_insert_policy" ON "cost_estimates"
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    jwt_has_project_permission(project_id, 'add_cost_estimation')
+  );
+
+-- Policy for UPDATE operations (editing cost estimates)
+-- Users can update cost estimates if they have the 'edit_cost_estimation' permission in their JWT
+CREATE POLICY "cost_estimates_update_policy" ON "cost_estimates"
+  FOR UPDATE
+  TO authenticated
+  USING (
+    jwt_has_project_permission(project_id, 'edit_cost_estimation')
+  );
+
+-- Policy for DELETE operations (removing cost estimates)
+-- Users can delete cost estimates if they have the 'delete_cost_estimation' permission in their JWT
+CREATE POLICY "cost_estimates_delete_policy" ON "cost_estimates"
+  FOR DELETE
+  TO authenticated
+  USING (
+    jwt_has_project_permission(project_id, 'delete_cost_estimation')
+  );

--- a/supabase/migrations/20260313081705_migrate_cost_estimates_triggers_to_jwt.sql
+++ b/supabase/migrations/20260313081705_migrate_cost_estimates_triggers_to_jwt.sql
@@ -82,7 +82,7 @@ BEGIN
 
 
     IF NEW.is_locked THEN
-      NEW.locked_by_user_id := (SELECT id FROM users WHERE credential_id = (auth.jwt()->>'sub')::uuid);
+      NEW.locked_by_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
       NEW.locked_at := now();
     ELSE
       NEW.locked_by_user_id := NULL;

--- a/supabase/migrations/20260313081705_migrate_cost_estimates_triggers_to_jwt.sql
+++ b/supabase/migrations/20260313081705_migrate_cost_estimates_triggers_to_jwt.sql
@@ -1,0 +1,97 @@
+-- Update trigger function to use JWT claims instead of database lookups
+-- This improves performance by reading permissions from JWT tokens
+
+CREATE OR REPLACE FUNCTION check_cost_estimate_update_permissions()
+RETURNS TRIGGER
+SET search_path = public
+AS $$
+DECLARE
+  delete_changed boolean;
+  lock_changed boolean;
+  immutable_changed boolean;
+BEGIN
+  IF current_user IS DISTINCT FROM 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  delete_changed := (OLD.deleted_at IS DISTINCT FROM NEW.deleted_at)
+    OR (NEW.deleted_at IS NOT NULL);
+  lock_changed := (OLD.is_locked IS DISTINCT FROM NEW.is_locked);
+
+  immutable_changed := ROW(
+    OLD.id,
+    OLD.project_id,
+    OLD.creator_user_id,
+    OLD.locked_by_user_id,
+    OLD.locked_at,
+    OLD.markup_type,
+    OLD.overall_markup_value_type,
+    OLD.overall_markup_value,
+    OLD.material_markup_value_type,
+    OLD.material_markup_value,
+    OLD.labor_markup_value_type,
+    OLD.labor_markup_value,
+    OLD.equipment_markup_value_type,
+    OLD.equipment_markup_value,
+    OLD.total_cost,
+    OLD.created_at
+  ) IS DISTINCT FROM ROW(
+    NEW.id,
+    NEW.project_id,
+    NEW.creator_user_id,
+    NEW.locked_by_user_id,
+    NEW.locked_at,
+    NEW.markup_type,
+    NEW.overall_markup_value_type,
+    NEW.overall_markup_value,
+    NEW.material_markup_value_type,
+    NEW.material_markup_value,
+    NEW.labor_markup_value_type,
+    NEW.labor_markup_value,
+    NEW.equipment_markup_value_type,
+    NEW.equipment_markup_value,
+    NEW.total_cost,
+    NEW.created_at
+  );
+
+  IF immutable_changed THEN
+    RAISE EXCEPTION 'Immutable columns on cost_estimates cannot be updated'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Use JWT claims instead of database lookup
+  IF delete_changed THEN
+    IF NOT jwt_has_project_permission(
+      NEW.project_id,
+      'delete_cost_estimation'
+    ) THEN
+      RAISE EXCEPTION 'Insufficient permissions: delete_cost_estimation required to mark as deleted'
+      USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  -- Use JWT claims instead of database lookup
+  IF lock_changed THEN
+    IF NOT jwt_has_project_permission(
+      NEW.project_id,
+      'lock_cost_estimation'
+    ) THEN
+      RAISE EXCEPTION 'Insufficient permissions: lock_cost_estimation required to modify lock columns'
+        USING ERRCODE = '42501';
+    END IF;
+
+
+    IF NEW.is_locked THEN
+      NEW.locked_by_user_id := (SELECT id FROM users WHERE credential_id = (auth.jwt()->>'sub')::uuid);
+      NEW.locked_at := now();
+    ELSE
+      NEW.locked_by_user_id := NULL;
+      NEW.locked_at := NULL;
+    END IF;
+  END IF;
+
+  NEW.updated_at = now();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20260413004017_add_internal_user_id_to_auth_hook.sql
+++ b/supabase/migrations/20260413004017_add_internal_user_id_to_auth_hook.sql
@@ -1,4 +1,6 @@
--- Create custom access token hook for injecting project permissions into JWT
+-- Add internal_user_id to custom access token hook
+-- This allows triggers to set user ID fields (like locked_by_user_id) without database lookups
+
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -8,8 +10,19 @@ AS $$
 DECLARE
   claims jsonb;
   projects_claims jsonb;
+  user_internal_id uuid;
 BEGIN
   claims := event->'claims';
+
+  -- Get the internal user ID (users.id) from credential_id
+  SELECT u.id INTO user_internal_id
+  FROM public.users u
+  WHERE u.credential_id = (event->>'user_id')::uuid;
+
+  IF user_internal_id IS NULL THEN
+  RAISE WARNING 'custom_access_token_hook: no users row for credential_id %',
+    (event->>'user_id')::uuid;
+  END IF;
 
   SELECT COALESCE(
     jsonb_object_agg(project_permissions.project_id, project_permissions.permissions),
@@ -29,12 +42,15 @@ BEGIN
     GROUP BY pm.project_id
   ) AS project_permissions;
 
-  -- Ensure app_metadata exists, then merge in projects
+  -- Ensure app_metadata exists, then merge in projects and internal_user_id
   -- This handles cases where claims don't yet have app_metadata (e.g., first login)
   claims := jsonb_set(
     claims,
     '{app_metadata}',
-    COALESCE(claims->'app_metadata', '{}'::jsonb) || jsonb_build_object('projects', projects_claims),
+    COALESCE(claims->'app_metadata', '{}'::jsonb) || jsonb_build_object(
+      'projects', projects_claims,
+      'internal_user_id', user_internal_id
+    ),
     true
   );
 
@@ -47,8 +63,3 @@ EXCEPTION WHEN OTHERS THEN
   RETURN event;
 END;
 $$;
-
--- Grant necessary permissions to supabase_auth_admin
-GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
-GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) TO supabase_auth_admin;
-REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb) FROM authenticated, anon, public;

--- a/supabase/schemas/cost_management/cost_estimates/03_functions.sql
+++ b/supabase/schemas/cost_management/cost_estimates/03_functions.sql
@@ -63,7 +63,6 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
-  -- Use JWT claims instead of database lookup
   IF delete_changed THEN
     IF NOT jwt_has_project_permission(
       NEW.project_id,
@@ -74,7 +73,6 @@ BEGIN
     END IF;
   END IF;
 
-  -- Use JWT claims instead of database lookup
   IF lock_changed THEN
     IF NOT jwt_has_project_permission(
       NEW.project_id,
@@ -184,27 +182,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_estimate_updated"() RETURNS "trigg
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_updated: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_updated: skipped logging for estimate %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_estimate_updated: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 
@@ -259,27 +247,17 @@ CREATE OR REPLACE FUNCTION "public"."log_cost_estimate_deleted"() RETURNS "trigg
     AS $$
 DECLARE
   v_user_id uuid;
-  v_auth_uid text;
 BEGIN
-  -- Get credential_id from JWT claims
+  -- Get internal_user_id from JWT app_metadata (migrated from database lookup)
   BEGIN
-    v_auth_uid := current_setting('request.jwt.claims', true)::json->>'sub';
+    v_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
   EXCEPTION WHEN OTHERS THEN
-    v_auth_uid := NULL;
+    v_user_id := NULL;
   END;
 
   -- Skip logging if no authenticated user (service role or migration context)
-  IF v_auth_uid IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_deleted: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
-    RETURN NEW;
-  END IF;
-
-  -- Look up user_id from credential_id
-  SELECT id INTO v_user_id FROM users WHERE credential_id = v_auth_uid::uuid;
-
-  -- Skip if user not found
   IF v_user_id IS NULL THEN
-    RAISE NOTICE 'log_cost_estimate_deleted: skipped logging for estimate %, user not found for credential %', NEW.id, v_auth_uid;
+    RAISE NOTICE 'log_cost_estimate_deleted: skipped logging for estimate %, no authenticated user (service role or migration context)', NEW.id;
     RETURN NEW;
   END IF;
 

--- a/supabase/schemas/cost_management/cost_estimates/03_functions.sql
+++ b/supabase/schemas/cost_management/cost_estimates/03_functions.sql
@@ -3,6 +3,7 @@
 
 -- Update Permission Guard
 -- Enforces column-level permissions and immutability rules for updates
+-- Migrated to JWT-based authorization for improved performance
 
 CREATE OR REPLACE FUNCTION "public"."check_cost_estimate_update_permissions"() RETURNS "trigger"
     LANGUAGE "plpgsql"
@@ -62,22 +63,22 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
+  -- Use JWT claims instead of database lookup
   IF delete_changed THEN
-    IF NOT "user_has_project_permission"(
+    IF NOT jwt_has_project_permission(
       NEW.project_id,
-      'delete_cost_estimation',
-      auth.uid()
+      'delete_cost_estimation'
     ) THEN
       RAISE EXCEPTION 'Insufficient permissions: delete_cost_estimation required to mark as deleted'
       USING ERRCODE = '42501';
     END IF;
   END IF;
 
+  -- Use JWT claims instead of database lookup
   IF lock_changed THEN
-    IF NOT "user_has_project_permission"(
+    IF NOT jwt_has_project_permission(
       NEW.project_id,
-      'lock_cost_estimation',
-      auth.uid()
+      'lock_cost_estimation'
     ) THEN
       RAISE EXCEPTION 'Insufficient permissions: lock_cost_estimation required to modify lock columns'
         USING ERRCODE = '42501';
@@ -85,7 +86,7 @@ BEGIN
 
 
     IF NEW.is_locked THEN
-      NEW.locked_by_user_id := (SELECT id FROM users WHERE credential_id = auth.uid());
+      NEW.locked_by_user_id := (auth.jwt()->'app_metadata'->>'internal_user_id')::uuid;
       NEW.locked_at := now();
     ELSE
       NEW.locked_by_user_id := NULL;

--- a/supabase/schemas/cost_management/cost_estimates/05_rls.sql
+++ b/supabase/schemas/cost_management/cost_estimates/05_rls.sql
@@ -1,30 +1,54 @@
 -- Cost Estimates RLS Policies
+-- Migrated to JWT-based authorization for improved performance
 
 ALTER TABLE "public"."cost_estimates" ENABLE ROW LEVEL SECURITY;
 
 
--- DELETE Policy
--- Users can delete estimates if they have delete_cost_estimation permission
+-- SELECT Policy
+-- Users can view cost estimates if they have the 'get_cost_estimations' permission in their JWT
 
-CREATE POLICY "cost_estimates_delete_policy" ON "public"."cost_estimates" FOR DELETE USING ("public"."user_has_project_permission"("project_id", 'delete_cost_estimation'::"text", "auth"."uid"()));
+CREATE POLICY "cost_estimates_select_policy" ON "public"."cost_estimates"
+  FOR SELECT
+  TO authenticated
+  USING (
+    jwt_has_project_permission(project_id, 'get_cost_estimations')
+  );
 
 
 -- INSERT Policy
--- Users can create estimates if they have add_cost_estimation permission
+-- Users can create cost estimates if they have the 'add_cost_estimation' permission in their JWT
 
-CREATE POLICY "cost_estimates_insert_policy" ON "public"."cost_estimates" FOR INSERT WITH CHECK ("public"."user_has_project_permission"("project_id", 'add_cost_estimation'::"text", "auth"."uid"()));
-
-
--- SELECT Policy
--- Users can view estimates if they have get_cost_estimations permission
-
-CREATE POLICY "cost_estimates_select_policy" ON "public"."cost_estimates" FOR SELECT USING ("public"."user_has_project_permission"("project_id", 'get_cost_estimations'::"text", "auth"."uid"()));
+CREATE POLICY "cost_estimates_insert_policy" ON "public"."cost_estimates"
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    jwt_has_project_permission(project_id, 'add_cost_estimation')
+  );
 
 
 -- UPDATE Policy
--- Users can edit estimates if they have edit_cost_estimation permission
+-- Users can update cost estimates if they have the 'edit_cost_estimation' permission in their JWT
 
-CREATE POLICY "cost_estimates_update_policy" ON "public"."cost_estimates" FOR UPDATE USING ("public"."user_has_project_permission"("project_id", 'edit_cost_estimation'::"text", "auth"."uid"()));
+CREATE POLICY "cost_estimates_update_policy" ON "public"."cost_estimates"
+  FOR UPDATE
+  TO authenticated
+  USING (
+    jwt_has_project_permission(project_id, 'edit_cost_estimation')
+  )
+  WITH CHECK (
+    jwt_has_project_permission(project_id, 'edit_cost_estimation')
+  );
+
+
+-- DELETE Policy
+-- Users can delete cost estimates if they have the 'delete_cost_estimation' permission in their JWT
+
+CREATE POLICY "cost_estimates_delete_policy" ON "public"."cost_estimates"
+  FOR DELETE
+  TO authenticated
+  USING (
+    jwt_has_project_permission(project_id, 'delete_cost_estimation')
+  );
 
 
 -- Restrictive Policy - Hide Soft Deleted

--- a/supabase/schemas/cost_management/cost_estimates/README.md
+++ b/supabase/schemas/cost_management/cost_estimates/README.md
@@ -90,7 +90,7 @@ All operations require specific project permissions:
 | UPDATE (lock) | `lock_cost_estimation` |
 | DELETE | `delete_cost_estimation` |
 
-Permissions are checked via `user_has_project_permission()` function.
+Permissions are checked via the `jwt_has_project_permission()` function, which reads permissions directly from JWT claims for improved performance (instead of querying the database).
 
 ## Functions
 
@@ -99,11 +99,13 @@ Permissions are checked via `user_has_project_permission()` function.
 
 **Responsibilities**:
 1. Enforce immutable column restrictions
-2. Check `delete_cost_estimation` permission for soft deletes
-3. Check `lock_cost_estimation` permission for lock changes
-4. Auto-populate `locked_by_user_id` and `locked_at` when locking
+2. Check `delete_cost_estimation` permission for soft deletes (via JWT claims)
+3. Check `lock_cost_estimation` permission for lock changes (via JWT claims)
+4. Auto-populate `locked_by_user_id` and `locked_at` when locking (user ID resolved from JWT `sub` claim)
 5. Auto-clear lock fields when unlocking
 6. Update `updated_at` timestamp
+
+**Note**: Uses `jwt_has_project_permission()` for permission checks and resolves user ID from `auth.jwt()->>'sub'` instead of `auth.uid()` for improved performance.
 
 ### `handle_soft_delete_cost_estimates()`
 **Trigger function** that runs before DELETE operations.
@@ -183,11 +185,15 @@ Performance indexes for common queries:
 
 ## RLS Policies
 
+Row Level Security policies use JWT-based authorization for improved performance by reading permissions directly from JWT tokens instead of querying the database.
+
 ### Permissive Policies (any can grant access)
-1. **cost_estimates_select_policy** - View if has `get_cost_estimations`
-2. **cost_estimates_insert_policy** - Create if has `add_cost_estimation`
-3. **cost_estimates_update_policy** - Edit if has `edit_cost_estimation`
-4. **cost_estimates_delete_policy** - Delete if has `delete_cost_estimation`
+1. **cost_estimates_select_policy** - View if has `get_cost_estimations` permission in JWT
+2. **cost_estimates_insert_policy** - Create if has `add_cost_estimation` permission in JWT
+3. **cost_estimates_update_policy** - Edit if has `edit_cost_estimation` permission in JWT
+4. **cost_estimates_delete_policy** - Delete if has `delete_cost_estimation` permission in JWT
+
+All permissive policies use `jwt_has_project_permission(project_id, '<permission>')` and target `authenticated` users.
 
 ### Restrictive Policy (must pass for all operations)
 5. **exclude_soft_deleted_estimates** - Hides rows where `deleted_at IS NOT NULL`

--- a/supabase/schemas/cost_management/cost_estimates/README.md
+++ b/supabase/schemas/cost_management/cost_estimates/README.md
@@ -101,11 +101,11 @@ Permissions are checked via the `jwt_has_project_permission()` function, which r
 1. Enforce immutable column restrictions
 2. Check `delete_cost_estimation` permission for soft deletes (via JWT claims)
 3. Check `lock_cost_estimation` permission for lock changes (via JWT claims)
-4. Auto-populate `locked_by_user_id` and `locked_at` when locking (user ID resolved from JWT `sub` claim)
+4. Auto-populate `locked_by_user_id` and `locked_at` when locking (user ID resolved from JWT `app_metadata.internal_user_id`)
 5. Auto-clear lock fields when unlocking
 6. Update `updated_at` timestamp
 
-**Note**: Uses `jwt_has_project_permission()` for permission checks and resolves user ID from `auth.jwt()->>'sub'` instead of `auth.uid()` for improved performance.
+**Note**: Uses `jwt_has_project_permission()` for permission checks and resolves user ID from `auth.jwt()->'app_metadata'->>'internal_user_id'` for improved performance.
 
 ### `handle_soft_delete_cost_estimates()`
 **Trigger function** that runs before DELETE operations.

--- a/supabase/tests/database/cost_estimate_activity_logging_test.sql
+++ b/supabase/tests/database/cost_estimate_activity_logging_test.sql
@@ -55,7 +55,7 @@ SELECT matches(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   UPDATE cost_estimates SET estimate_name = 'Renamed Estimate' WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 END $$;
 
@@ -94,7 +94,7 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   UPDATE cost_estimates SET is_locked = true WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 END $$;
 
@@ -116,7 +116,7 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   UPDATE cost_estimates SET is_locked = false WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 END $$;
 
@@ -137,7 +137,7 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   INSERT INTO cost_files (
     id, project_id, filename, content_type, file_size_bytes, uploaded_by_user_id, file_url, version
   ) VALUES (
@@ -187,7 +187,7 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   DELETE FROM cost_files WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 END $$;
 
@@ -242,7 +242,7 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   INSERT INTO cost_items (
     id, estimate_id, item_name, item_type, unit_price, quantity, unit_measurement, 
     calculation, item_total_cost, currency
@@ -301,8 +301,8 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
-  UPDATE cost_items 
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
+  UPDATE cost_items
   SET item_name = 'Updated Cost Item', unit_price = 150.00
   WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 END $$;
@@ -372,7 +372,7 @@ SELECT is(
 -- =============================================================
 DO $$
 BEGIN
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
   UPDATE cost_items SET deleted_at = now() WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 END $$;
 
@@ -418,8 +418,8 @@ SELECT is(
 DO $$
 BEGIN
   -- Re-authenticate
-  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
-  
+  PERFORM set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222","app_metadata":{"internal_user_id":"11111111-1111-1111-1111-111111111111"}}', true);
+
   -- Insert a fresh item for test 11 to avoid interference from previous tests
   INSERT INTO cost_items (
     id, estimate_id, item_name, item_type, unit_price, quantity, unit_measurement, 

--- a/supabase/tests/database/cost_estimates_update_guard_test.sql
+++ b/supabase/tests/database/cost_estimates_update_guard_test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(10);
+select plan(11);
 
 DO $$
 DECLARE
@@ -55,6 +55,7 @@ SET LOCAL ROLE authenticated;
 SELECT set_config('request.jwt.claims', '{
   "sub": "22222222-2222-2222-2222-222222222222",
   "app_metadata": {
+    "internal_user_id": "11111111-1111-1111-1111-111111111111",
     "projects": {
       "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation", "lock_cost_estimation"]
     }
@@ -77,6 +78,7 @@ SELECT throws_ok(
 SELECT set_config('request.jwt.claims', '{
   "sub": "99999999-9999-9999-9999-999999999999",
   "app_metadata": {
+    "internal_user_id": "88888888-8888-8888-8888-888888888888",
     "projects": {
       "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation"]
     }
@@ -96,6 +98,7 @@ SELECT throws_ok(
 SELECT set_config('request.jwt.claims', '{
   "sub": "22222222-2222-2222-2222-222222222222",
   "app_metadata": {
+    "internal_user_id": "11111111-1111-1111-1111-111111111111",
     "projects": {
       "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation", "lock_cost_estimation"]
     }
@@ -133,6 +136,7 @@ SET LOCAL ROLE authenticated;
 SELECT set_config('request.jwt.claims', '{
   "sub": "22222222-2222-2222-2222-222222222222",
   "app_metadata": {
+    "internal_user_id": "11111111-1111-1111-1111-111111111111",
     "projects": {
       "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation", "lock_cost_estimation"]
     }
@@ -161,6 +165,7 @@ SET LOCAL ROLE authenticated;
 SELECT set_config('request.jwt.claims', '{
   "sub": "99999999-9999-9999-9999-999999999999",
   "app_metadata": {
+    "internal_user_id": "88888888-8888-8888-8888-888888888888",
     "projects": {
       "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation"]
     }
@@ -190,6 +195,7 @@ SET LOCAL ROLE authenticated;
 SELECT set_config('request.jwt.claims', '{
   "sub": "dddddddd-dddd-dddd-dddd-dddddddddddd",
   "app_metadata": {
+    "internal_user_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
     "projects": {
       "33333333-3333-3333-3333-333333333333": ["get_cost_estimations"]
     }
@@ -205,6 +211,29 @@ SELECT is(
   'Renamed Estimate',
   'RLS blocks viewer without edit_cost_estimation from updating'
 );
+
+-- =============================================================
+-- Test 11: Collaborator with edit but not delete permission cannot soft-delete
+-- =============================================================
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims', '{
+  "sub": "99999999-9999-9999-9999-999999999999",
+  "app_metadata": {
+    "internal_user_id": "88888888-8888-8888-8888-888888888888",
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation"]
+    }
+  }
+}', true);
+
+SELECT throws_ok(
+  $$ UPDATE cost_estimates SET deleted_at = now() WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' $$,
+  '42501',
+  'Insufficient permissions: delete_cost_estimation required to mark as deleted',
+  'Collaborator without delete_cost_estimation cannot soft-delete'
+);
+
+RESET ROLE;
 
 select * from finish();
 rollback;

--- a/supabase/tests/database/cost_estimates_update_guard_test.sql
+++ b/supabase/tests/database/cost_estimates_update_guard_test.sql
@@ -52,7 +52,14 @@ BEGIN
 END $$;
 
 SET LOCAL ROLE authenticated;
-SELECT set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+SELECT set_config('request.jwt.claims', '{
+  "sub": "22222222-2222-2222-2222-222222222222",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation", "lock_cost_estimation"]
+    }
+  }
+}', true);
 
 -- =============================================================
 -- Test 1: Immutable guard blocks creator_user_id change
@@ -67,7 +74,14 @@ SELECT throws_ok(
 -- =============================================================
 -- Test 2: Collaborator (no lock permission) cannot lock estimate
 -- =============================================================
-SELECT set_config('request.jwt.claims', '{"sub":"99999999-9999-9999-9999-999999999999"}', true);
+SELECT set_config('request.jwt.claims', '{
+  "sub": "99999999-9999-9999-9999-999999999999",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation"]
+    }
+  }
+}', true);
 
 SELECT throws_ok(
   $$ UPDATE cost_estimates SET is_locked = true WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' $$,
@@ -79,7 +93,14 @@ SELECT throws_ok(
 -- =============================================================
 -- Test 3: Admin can lock by setting is_locked = true
 -- =============================================================
-SELECT set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+SELECT set_config('request.jwt.claims', '{
+  "sub": "22222222-2222-2222-2222-222222222222",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation", "lock_cost_estimation"]
+    }
+  }
+}', true);
 
 SELECT lives_ok(
   $$ UPDATE cost_estimates SET is_locked = true WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' $$,
@@ -109,7 +130,14 @@ SELECT isnt_empty(
 -- Test 6: Admin can unlock by setting is_locked = false
 -- =============================================================
 SET LOCAL ROLE authenticated;
-SELECT set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+SELECT set_config('request.jwt.claims', '{
+  "sub": "22222222-2222-2222-2222-222222222222",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation", "lock_cost_estimation"]
+    }
+  }
+}', true);
 
 SELECT lives_ok(
   $$ UPDATE cost_estimates SET is_locked = false WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' $$,
@@ -130,7 +158,14 @@ SELECT is_empty(
 -- Test 8: Collaborator can update estimate_name (allowed column)
 -- =============================================================
 SET LOCAL ROLE authenticated;
-SELECT set_config('request.jwt.claims', '{"sub":"99999999-9999-9999-9999-999999999999"}', true);
+SELECT set_config('request.jwt.claims', '{
+  "sub": "99999999-9999-9999-9999-999999999999",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations", "edit_cost_estimation"]
+    }
+  }
+}', true);
 
 SELECT lives_ok(
   $$ UPDATE cost_estimates SET estimate_name = 'Renamed Estimate' WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' $$,
@@ -152,7 +187,14 @@ SELECT is(
 -- Test 10: Viewer without edit_cost_estimation blocked by RLS
 -- =============================================================
 SET LOCAL ROLE authenticated;
-SELECT set_config('request.jwt.claims', '{"sub":"dddddddd-dddd-dddd-dddd-dddddddddddd"}', true);
+SELECT set_config('request.jwt.claims', '{
+  "sub": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations"]
+    }
+  }
+}', true);
 
 UPDATE cost_estimates SET estimate_name = 'Should Not Change' WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 

--- a/supabase/tests/functions/custom_access_token_hook_test.sql
+++ b/supabase/tests/functions/custom_access_token_hook_test.sql
@@ -226,6 +226,19 @@ BEGIN
       actual_permissions::text;
   END IF;
 
+  -- Verify internal_user_id is present in app_metadata
+  IF NOT (result->'claims'->'app_metadata' ? 'internal_user_id') THEN
+    RAISE EXCEPTION 'app_metadata.internal_user_id should exist. Got: %',
+      (result->'claims'->'app_metadata')::text;
+  END IF;
+
+  -- Verify internal_user_id matches the test user's ID
+  IF (result->'claims'->'app_metadata'->>'internal_user_id')::uuid != test_user_id THEN
+    RAISE EXCEPTION 'internal_user_id should match user ID. Expected: %, Got: %',
+      test_user_id::text,
+      (result->'claims'->'app_metadata'->>'internal_user_id')::text;
+  END IF;
+
 END $$;
 SELECT ok(true, 'Hook correctly injects real user permissions for project memberships');
 


### PR DESCRIPTION
# PR Review: feat/update-cost-estimate-for-declarative-approach → feat/migrate-cost-estimate-policies-to-jwt-auth
**Reviewed:** Mon Apr 13 2026

---

## 1. PR SUMMARY

This PR migrates the `cost_estimates` schema from database-lookup-based authorization (`user_has_project_permission()` + `auth.uid()`) to JWT-based authorization (`jwt_has_project_permission()` + `auth.jwt()`) for improved performance. The changes span three files: the trigger function `03_functions.sql`, the RLS policies `05_rls.sql`, and the module `README.md`. The RLS policies are also reformatted to a multi-line declarative style and explicitly scoped to the `authenticated` role. The UPDATE policy gains a `WITH CHECK` clause that was missing before.

**PR Size:** XS — 14 + 36 + 14 = 64 total lines changed across 3 files, all within a single focused concern. ✅

---

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| Duplicate lines in `03_functions.sql` | Both the `delete_changed` and `lock_changed` blocks contain duplicated comment lines, duplicated `jwt_has_project_permission(` call openings, and duplicated string literals without commas.  |  ✅ | |
| Unnecessary `auth.jwt()->>'sub'` substitution | `(auth.jwt()->>'sub')::uuid` is functionally identical to `auth.uid()` in Supabase. The substitution adds verbosity with no behavioral or performance benefit. Worth reverting or explicitly documenting as intentional cosmetic consistency. |  ✅ | |