### PR TITLE
CA-687: Feat: Implement project search history module with RLS and RPC

### DIFF
--- a/supabase/migrations/20260520112528_33_project_search_history.sql
+++ b/supabase/migrations/20260520112528_33_project_search_history.sql
@@ -1,0 +1,54 @@
+SET check_function_bodies = false;
+CREATE FUNCTION public.get_project_search_suggestions(user_id uuid)
+ RETURNS text[]
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_suggestions text[];
+BEGIN
+
+  -- Anti-spoof guard: reject calls where the passed user_id does not
+  -- match the authenticated session. Prevents parameter spoofing via
+  -- the PostgREST API even though RLS would silently return empty rows.
+  IF user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized: user_id must match the authenticated session'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Step 1: Personal history — own searches that returned results
+  SELECT ARRAY(
+    SELECT psh.search_term
+    FROM project_search_history psh
+    WHERE psh.user_id = auth.uid()
+      AND psh.has_results = true
+    ORDER BY psh.search_count DESC
+    LIMIT 10
+  ) INTO v_suggestions;
+
+  -- Step 2: empty array if nothing found
+  RETURN COALESCE(v_suggestions, ARRAY[]::text[]);
+
+END;
+$function$;
+COMMENT ON FUNCTION public.get_project_search_suggestions(uuid) IS 'Returns up to 10 search-term suggestions for the Project Search feature.
+Accepts user_id uuid — must match auth.uid() or raises 42501.
+Step 1: caller own history (has_results=true), ordered by frequency.
+Step 2: empty array if no personal history.
+SECURITY INVOKER — RLS on project_search_history enforces visibility.
+Does NOT expose users.credential_id or any auth identifier.
+has_results contract: caller must upsert with has_results=true after a non-empty result set.
+Rows with has_results=false are stored but excluded from suggestions.';
+CREATE TABLE public.project_search_history (id uuid DEFAULT gen_random_uuid() NOT NULL, user_id uuid NOT NULL, search_term character varying(255) NOT NULL, has_results boolean DEFAULT false NOT NULL, search_count integer DEFAULT 1 NOT NULL, created_at timestamp with time zone DEFAULT now() NOT NULL, updated_at timestamp with time zone DEFAULT now() NOT NULL);
+ALTER TABLE public.project_search_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_search_history ADD CONSTRAINT project_search_history_pkey PRIMARY KEY (id);
+CREATE INDEX project_search_history_updated_at_idx ON public.project_search_history (updated_at);
+CREATE UNIQUE INDEX project_search_history_user_term_uq ON public.project_search_history (user_id, search_term);
+CREATE INDEX project_search_history_user_id_idx ON public.project_search_history (user_id);
+CREATE INDEX project_search_history_has_results_idx ON public.project_search_history (has_results) WHERE has_results = true;
+CREATE TRIGGER trigger_increment_project_search_count BEFORE UPDATE ON public.project_search_history FOR EACH ROW WHEN (NOT old.user_id IS DISTINCT FROM new.user_id AND NOT old.search_term::text IS DISTINCT FROM new.search_term::text) EXECUTE FUNCTION public.increment_search_count();
+CREATE TRIGGER trigger_set_project_search_history_updated_at BEFORE UPDATE ON public.project_search_history FOR EACH ROW EXECUTE FUNCTION public.set_search_history_updated_at();
+CREATE POLICY project_search_history_delete_policy ON public.project_search_history FOR DELETE USING ((user_id = auth.uid()));
+CREATE POLICY project_search_history_insert_policy ON public.project_search_history FOR INSERT WITH CHECK ((user_id = auth.uid()));
+CREATE POLICY project_search_history_select_policy ON public.project_search_history FOR SELECT USING ((user_id = auth.uid()));
+CREATE POLICY project_search_history_update_policy ON public.project_search_history FOR UPDATE USING ((user_id = auth.uid()));

--- a/supabase/migrations/20260520112528_33_project_search_history.sql
+++ b/supabase/migrations/20260520112528_33_project_search_history.sql
@@ -4,8 +4,6 @@ CREATE FUNCTION public.get_project_search_suggestions(user_id uuid)
  LANGUAGE plpgsql
  SET search_path TO 'public'
 AS $function$
-DECLARE
-  v_suggestions text[];
 BEGIN
 
   -- Anti-spoof guard: reject calls where the passed user_id does not
@@ -16,18 +14,17 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
-  -- Step 1: Personal history — own searches that returned results
-  SELECT ARRAY(
+  -- Personal history — own searches that returned results.
+  -- SELECT ARRAY(subquery) returns '{}'::text[] when the subquery is empty,
+  -- never NULL, so no COALESCE fallback is required.
+  RETURN ARRAY(
     SELECT psh.search_term
     FROM project_search_history psh
     WHERE psh.user_id = auth.uid()
       AND psh.has_results = true
     ORDER BY psh.search_count DESC
     LIMIT 10
-  ) INTO v_suggestions;
-
-  -- Step 2: empty array if nothing found
-  RETURN COALESCE(v_suggestions, ARRAY[]::text[]);
+  );
 
 END;
 $function$;
@@ -46,8 +43,8 @@ CREATE INDEX project_search_history_updated_at_idx ON public.project_search_hist
 CREATE UNIQUE INDEX project_search_history_user_term_uq ON public.project_search_history (user_id, search_term);
 CREATE INDEX project_search_history_user_id_idx ON public.project_search_history (user_id);
 CREATE INDEX project_search_history_has_results_idx ON public.project_search_history (has_results) WHERE has_results = true;
-CREATE TRIGGER trigger_increment_project_search_count BEFORE UPDATE ON public.project_search_history FOR EACH ROW WHEN (NOT old.user_id IS DISTINCT FROM new.user_id AND NOT old.search_term::text IS DISTINCT FROM new.search_term::text) EXECUTE FUNCTION public.increment_search_count();
-CREATE TRIGGER trigger_set_project_search_history_updated_at BEFORE UPDATE ON public.project_search_history FOR EACH ROW EXECUTE FUNCTION public.set_search_history_updated_at();
+CREATE OR REPLACE TRIGGER trigger_increment_project_search_count BEFORE UPDATE ON public.project_search_history FOR EACH ROW WHEN (NOT old.user_id IS DISTINCT FROM new.user_id AND NOT old.search_term::text IS DISTINCT FROM new.search_term::text) EXECUTE FUNCTION public.increment_search_count();
+CREATE OR REPLACE TRIGGER trigger_set_project_search_history_updated_at BEFORE UPDATE ON public.project_search_history FOR EACH ROW EXECUTE FUNCTION public.set_search_history_updated_at();
 CREATE POLICY project_search_history_delete_policy ON public.project_search_history FOR DELETE USING ((user_id = auth.uid()));
 CREATE POLICY project_search_history_insert_policy ON public.project_search_history FOR INSERT WITH CHECK ((user_id = auth.uid()));
 CREATE POLICY project_search_history_select_policy ON public.project_search_history FOR SELECT USING ((user_id = auth.uid()));

--- a/supabase/schemas/global_search/project_search_history/01_table.sql
+++ b/supabase/schemas/global_search/project_search_history/01_table.sql
@@ -1,0 +1,21 @@
+-- project_search_history table
+-- Per-user search-term log for the dedicated Project Search feature.
+-- Powers Project Search's "recent searches" and "suggestions" surfaces.
+--
+-- Project Search is a separate feature from Global Search:
+--   * Global Search (search_history)   — searches across projects/members/estimates
+--   * Project Search (this table)      — searches ONLY for projects
+-- The two features are fully isolated: neither reads from nor writes to the
+-- other's table.
+
+CREATE TABLE IF NOT EXISTS "public"."project_search_history" (
+  "id"           uuid PRIMARY KEY DEFAULT (gen_random_uuid()),
+  "user_id"      uuid NOT NULL, -- auth.uid(); no FK (cross-schema boundary with auth.users)
+  "search_term"  varchar(255) NOT NULL,
+  "has_results"  boolean NOT NULL DEFAULT false,
+  "search_count" int NOT NULL DEFAULT 1,
+  "created_at"   timestamptz NOT NULL DEFAULT (now()),
+  "updated_at"   timestamptz NOT NULL DEFAULT (now())
+);
+
+ALTER TABLE "public"."project_search_history" OWNER TO "postgres";

--- a/supabase/schemas/global_search/project_search_history/02_indexes.sql
+++ b/supabase/schemas/global_search/project_search_history/02_indexes.sql
@@ -1,0 +1,17 @@
+-- Indexes for project_search_history
+
+-- Unique constraint: drives upsert conflict resolution (user_id, search_term)
+CREATE UNIQUE INDEX IF NOT EXISTS "project_search_history_user_term_uq"
+  ON "public"."project_search_history" ("user_id", "search_term");
+
+CREATE INDEX IF NOT EXISTS "project_search_history_user_id_idx"
+  ON "public"."project_search_history" ("user_id");
+
+-- Partial index: only indexes rows where suggestions are eligible.
+-- Covers the WHERE has_results = true predicate in get_project_search_suggestions.
+CREATE INDEX IF NOT EXISTS "project_search_history_has_results_idx"
+  ON "public"."project_search_history" ("has_results") WHERE has_results = true;
+
+-- Supports the recent-searches surface (ORDER BY updated_at DESC).
+CREATE INDEX IF NOT EXISTS "project_search_history_updated_at_idx"
+  ON "public"."project_search_history" ("updated_at");

--- a/supabase/schemas/global_search/project_search_history/03_functions.sql
+++ b/supabase/schemas/global_search/project_search_history/03_functions.sql
@@ -48,8 +48,6 @@ LANGUAGE plpgsql
 SECURITY INVOKER
 SET search_path = public
 AS $$
-DECLARE
-  v_suggestions text[];
 BEGIN
 
   -- Anti-spoof guard: reject calls where the passed user_id does not
@@ -60,18 +58,17 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
-  -- Step 1: Personal history — own searches that returned results
-  SELECT ARRAY(
+  -- Personal history — own searches that returned results.
+  -- SELECT ARRAY(subquery) returns '{}'::text[] when the subquery is empty,
+  -- never NULL, so no COALESCE fallback is required.
+  RETURN ARRAY(
     SELECT psh.search_term
     FROM project_search_history psh
     WHERE psh.user_id = auth.uid()
       AND psh.has_results = true
     ORDER BY psh.search_count DESC
     LIMIT 10
-  ) INTO v_suggestions;
-
-  -- Step 2: empty array if nothing found
-  RETURN COALESCE(v_suggestions, ARRAY[]::text[]);
+  );
 
 END;
 $$;

--- a/supabase/schemas/global_search/project_search_history/03_functions.sql
+++ b/supabase/schemas/global_search/project_search_history/03_functions.sql
@@ -1,0 +1,87 @@
+-- Functions for the Project Search feature.
+-- Only contains the suggestions RPC. The BEFORE UPDATE trigger functions
+-- are reused from the global search_history module:
+--   * public.increment_search_count        (sets NEW.search_count := OLD.search_count + 1)
+--   * public.set_search_history_updated_at (sets NEW.updated_at := now())
+-- Both are table-agnostic and attached in 04_triggers.sql.
+
+-- ============================================================
+-- get_project_search_suggestions RPC
+--
+-- Parameters:
+--   user_id uuid — must match auth.uid() (validated at entry).
+--     Caller must pass their own auth UID; the guard rejects any other UUID.
+-- Returns: text[]
+--
+-- Two-step priority logic:
+--
+-- Step 1 — Personal History:
+--   Search project_search_history for auth.uid() where has_results = true.
+--   Order by search_count DESC, limit 10.
+--
+-- Step 2 — Empty Array:
+--   Return empty array if Step 1 yields nothing.
+--
+-- Project Search is fully isolated from Global Search; no fallback into
+-- search_history or any other table.
+--
+-- SECURITY INVOKER: RLS on project_search_history enforces visibility
+-- (users can only read their own rows).
+--
+-- Privacy: this function returns only search-term strings. It does NOT
+-- select users.credential_id or any other auth identifier. (Prior review
+-- caught credential_id leakage on the global search RPC — that mistake
+-- must not be repeated here.)
+--
+-- has_results contract:
+--   project_search_history.has_results defaults to false on insert.
+--   The caller is responsible for upserting again with has_results = true
+--   after confirming the search returned at least one result. Rows with
+--   has_results = false are stored in history (and surface in recent
+--   searches) but are excluded from suggestions.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_project_search_suggestions(
+  user_id uuid
+)
+RETURNS text[]
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_suggestions text[];
+BEGIN
+
+  -- Anti-spoof guard: reject calls where the passed user_id does not
+  -- match the authenticated session. Prevents parameter spoofing via
+  -- the PostgREST API even though RLS would silently return empty rows.
+  IF user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Unauthorized: user_id must match the authenticated session'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Step 1: Personal history — own searches that returned results
+  SELECT ARRAY(
+    SELECT psh.search_term
+    FROM project_search_history psh
+    WHERE psh.user_id = auth.uid()
+      AND psh.has_results = true
+    ORDER BY psh.search_count DESC
+    LIMIT 10
+  ) INTO v_suggestions;
+
+  -- Step 2: empty array if nothing found
+  RETURN COALESCE(v_suggestions, ARRAY[]::text[]);
+
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_project_search_suggestions IS
+'Returns up to 10 search-term suggestions for the Project Search feature.
+Accepts user_id uuid — must match auth.uid() or raises 42501.
+Step 1: caller own history (has_results=true), ordered by frequency.
+Step 2: empty array if no personal history.
+SECURITY INVOKER — RLS on project_search_history enforces visibility.
+Does NOT expose users.credential_id or any auth identifier.
+has_results contract: caller must upsert with has_results=true after a non-empty result set.
+Rows with has_results=false are stored but excluded from suggestions.';

--- a/supabase/schemas/global_search/project_search_history/04_triggers.sql
+++ b/supabase/schemas/global_search/project_search_history/04_triggers.sql
@@ -1,0 +1,34 @@
+-- Triggers for project_search_history.
+-- Reuses trigger functions defined in
+-- supabase/schemas/global_search/search_history/03_functions.sql:
+--   * public.increment_search_count
+--   * public.set_search_history_updated_at
+-- Both are table-agnostic (they only touch NEW.search_count / NEW.updated_at)
+-- and can be safely attached here without redefinition.
+
+-- ============================================================
+-- Atomically increment search_count on repeat-search upserts.
+--
+-- WHEN guard: fires only when the upsert conflict key columns
+-- (user_id, search_term) are unchanged, scoping the trigger strictly
+-- to the repeat-search upsert path.
+--
+-- BEFORE UPDATE means created_at is never touched on conflict, so the
+-- original timestamp is preserved as required by the AC.
+-- ============================================================
+CREATE OR REPLACE TRIGGER "trigger_increment_project_search_count"
+  BEFORE UPDATE ON "public"."project_search_history"
+  FOR EACH ROW
+  WHEN (
+    OLD.user_id IS NOT DISTINCT FROM NEW.user_id
+    AND OLD.search_term IS NOT DISTINCT FROM NEW.search_term
+  )
+  EXECUTE FUNCTION public.increment_search_count();
+
+-- ============================================================
+-- Maintain updated_at on every row change.
+-- ============================================================
+CREATE OR REPLACE TRIGGER "trigger_set_project_search_history_updated_at"
+  BEFORE UPDATE ON "public"."project_search_history"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_search_history_updated_at();

--- a/supabase/schemas/global_search/project_search_history/05_rls.sql
+++ b/supabase/schemas/global_search/project_search_history/05_rls.sql
@@ -1,0 +1,25 @@
+-- RLS policies for project_search_history
+-- Four policies, all personal ownership: SELECT / INSERT / UPDATE / DELETE.
+-- Project Search history is personal — there is no cross-user visibility.
+
+ALTER TABLE "public"."project_search_history" ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- Personal ownership.
+-- user_id stores auth.uid() directly (= users.credential_id).
+-- ============================================================
+CREATE POLICY "project_search_history_select_policy" ON "public"."project_search_history"
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "project_search_history_insert_policy" ON "public"."project_search_history"
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "project_search_history_update_policy" ON "public"."project_search_history"
+  FOR UPDATE
+  USING (user_id = auth.uid());
+
+CREATE POLICY "project_search_history_delete_policy" ON "public"."project_search_history"
+  FOR DELETE
+  USING (user_id = auth.uid());

--- a/supabase/schemas/global_search/project_search_history/README.md
+++ b/supabase/schemas/global_search/project_search_history/README.md
@@ -1,0 +1,153 @@
+# Project Search — `project_search_history` Module
+
+## Overview
+
+The `project_search_history` table records every search term submitted by a user to the **Project Search** feature — a dedicated search surface whose only target is **projects**. It powers two surfaces:
+
+1. **Recent searches** — the user's own most-recently submitted terms (ordered by `updated_at DESC`).
+2. **Search suggestions** — the user's own most-frequently submitted terms that returned at least one result (ordered by `search_count DESC`).
+
+### Project Search vs Global Search
+
+Project Search is **completely independent** from Global Search:
+
+| Feature | Backed by | Searches across |
+|---|---|---|
+| **Global Search** | `public.search_history` (with `scope` column) | projects + members + cost estimates |
+| **Project Search** | `public.project_search_history` (this module) | projects only |
+
+Neither feature reads from or writes to the other's table. A search submitted via Global Search lands in `search_history` and never appears in Project Search's recent/suggestions. The same applies in reverse.
+
+---
+
+## Table Structure
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `uuid` | Primary key, auto-generated. |
+| `user_id` | `uuid NOT NULL` | `auth.uid()` of the searching user. No FK — cross-schema boundary with `auth.users`. See Orphan Risk below. |
+| `search_term` | `varchar(255) NOT NULL` | Normalised (lowercased, trimmed) search query. |
+| `has_results` | `boolean NOT NULL DEFAULT false` | Set to `true` by the caller after confirming the search returned at least one result. Only rows with `has_results = true` appear in suggestions; recent searches show all rows. |
+| `search_count` | `int NOT NULL DEFAULT 1` | Number of times this user has searched this term. Incremented atomically by `trigger_increment_project_search_count` on upsert conflicts. |
+| `created_at` | `timestamptz NOT NULL` | Row creation timestamp. Preserved on upsert conflicts. |
+| `updated_at` | `timestamptz NOT NULL` | Last modification timestamp. Maintained by `trigger_set_project_search_history_updated_at`. Drives the recent-searches ordering. |
+
+---
+
+## Business Rules
+
+### 1. Upsert on Conflict
+
+Rows are written via upsert with `ON CONFLICT (user_id, search_term)`. When the same user searches the same term again, the existing row is updated rather than a new one inserted. `search_count` is incremented atomically by the trigger, and `created_at` is preserved (BEFORE UPDATE triggers never touch it, and the upsert's `DO UPDATE SET` clause must not list `created_at`).
+
+### 2. `has_results` Contract
+
+`has_results` defaults to `false` on every insert. The caller is responsible for re-upserting with `has_results = true` after confirming the search returned at least one result. Rows with `has_results = false` are saved in history (visible to the user in recent searches) but excluded from suggestions.
+
+### 3. Personal Only
+
+Project Search history is personal — there is no teammate or cross-user visibility. A user only ever sees their own rows.
+
+### 4. Orphan Risk
+
+`user_id` has no foreign key to `auth.users` (cross-schema boundary). Rows are not cascade-deleted when a user is removed. A periodic cleanup job should purge rows where `user_id` no longer exists in `auth.users`.
+
+> **TODO ([CA-597](https://ripplearc.youtrack.cloud/issue/CA-597)):** The same orphan-cleanup ticket that covers `search_history` should also purge `project_search_history` rows whose `user_id` no longer exists in `auth.users`. Extend the cleanup job's scope when CA-597 is implemented.
+
+---
+
+## Indexes
+
+| Name | Column(s) | Purpose |
+|---|---|---|
+| `project_search_history_user_term_uq` | `(user_id, search_term)` | Unique constraint; drives upsert conflict resolution. |
+| `project_search_history_user_id_idx` | `user_id` | Fast lookup of all history for a user. |
+| `project_search_history_has_results_idx` | `has_results` (partial: `WHERE has_results = true`) | Fast filtering for suggestion queries. |
+| `project_search_history_updated_at_idx` | `updated_at` | Sorting recent searches by time. |
+
+---
+
+## Triggers
+
+Both trigger functions are reused from the global `search_history` module — they only touch `NEW.search_count` / `NEW.updated_at` and are table-agnostic.
+
+### `trigger_increment_project_search_count` — `BEFORE UPDATE`
+
+Atomically increments `search_count` when an upsert conflict is resolved.
+
+**WHEN guard:** fires only when `user_id` and `search_term` are both unchanged — scoping it to the repeat-search upsert path.
+
+### `trigger_set_project_search_history_updated_at` — `BEFORE UPDATE`
+
+Sets `updated_at = now()` on every row change.
+
+---
+
+## RLS Policies
+
+| Policy | Operation | Rule |
+|---|---|---|
+| `project_search_history_select_policy` | SELECT | User can read their own rows (`user_id = auth.uid()`). |
+| `project_search_history_insert_policy` | INSERT | User can insert rows for themselves (`user_id = auth.uid()`). |
+| `project_search_history_update_policy` | UPDATE | User can update their own rows (`user_id = auth.uid()`). |
+| `project_search_history_delete_policy` | DELETE | User can delete their own rows (`user_id = auth.uid()`). |
+
+---
+
+## RPC
+
+### `public.get_project_search_suggestions(user_id uuid)`
+
+Returns up to 10 personalised search-term suggestions using a two-step priority:
+
+1. **Personal history** — the caller's own searches with `has_results = true`, ordered by frequency.
+2. **Empty array** — if the caller has no qualifying history.
+
+**Security:** `SECURITY INVOKER`. Anti-spoof guard rejects calls where the `user_id` parameter does not match `auth.uid()` (raises `42501`).
+
+**Privacy:** the RPC returns only `text[]` of search terms. It does not select `users.credential_id` or any other auth identifier.
+
+**Recent searches** are read with a direct `SELECT` against the table (RLS-gated), so no dedicated RPC is required for that surface:
+
+```sql
+SELECT search_term, updated_at
+FROM project_search_history
+WHERE user_id = auth.uid()
+ORDER BY updated_at DESC
+LIMIT <n>;
+```
+
+---
+
+## Source-of-Truth Workflow
+
+Edit only the files in this folder. The standard `supabase db diff -f <name>` invocation uses a fresh shadow database; for this module a fresh shadow DB is acceptable (no cross-module FKs), but the same live-diff workflow is documented for parity with sibling modules:
+
+```bash
+# 1) Reset local DB to baseline (applies all existing migrations).
+supabase db reset
+
+# 2) Apply this module's schemas to the running local DB.
+for f in supabase/schemas/global_search/project_search_history/0?_*.sql; do
+  docker exec -i supabase_db_construculator-backend \
+    psql -U postgres -d postgres -v ON_ERROR_STOP=1 < "$f"
+done
+
+# 3) Emit the migration from the live diff. db diff prints to stdout
+#    when invoked this way, so redirect into the migrations folder.
+TS=$(date -u +"%Y%m%d%H%M%S")
+supabase db diff --from=migrations --to=local 2>/dev/null \
+  | grep -v "^A new version\|^We recommend" \
+  > "supabase/migrations/${TS}_33_project_search_history.sql"
+
+# 4) Reset once more to confirm the generated migration applies cleanly.
+supabase db reset
+```
+
+Review the generated migration file and commit both layers together. Do **not** hand-author migration files.
+
+---
+
+## Related Tables
+
+- `search_history` (sibling module) — the global search history. **Separate feature; this module does not read from or write to it.**


### PR DESCRIPTION
## 1. PR SUMMARY

Adds the backend for the **Project Search** feature — a dedicated, dashboard-level search surface whose only target is projects. Ships `public.project_search_history` (user_id, search_term, has_results, search_count, timestamps), 4 personal-ownership RLS policies, two `BEFORE UPDATE` triggers reusing the global `search_history` trigger functions, and `public.get_project_search_suggestions(user_id)` RPC (SECURITY INVOKER, anti-spoof guarded, two-step personal→empty).

---

## 2. REVIEW SUMMARY TABLE

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Wrong feature scope (project-scoped vs Project Search) | Original implementation assumed searches happened *inside* a project (`project_id NOT NULL FK`, teammate visibility, RPC took `project_id` param). The actual feature is the Project Search dashboard surface — no project context exists at search time. | ✅ Addressed | Dropped `project_id` column, FK, and CASCADE; unique key now `(user_id, search_term)`; removed teammate SELECT policy; removed membership-gated INSERT; RPC signature is now `get_project_search_suggestions(user_id)` with two-step (personal → empty); README rewritten to reflect Project Search as a standalone feature isolated from Global Search; migration regenerated. |
| `CA-XXX` placeholder | README orphan-cleanup TODO had no real YouTrack ID (B2 from prior global_search PR review) | ✅ Addressed | Linked to `CA-597` |
| "Two-step" comment was previously wrong | RPC docstring said 2 steps on a 3-step algorithm | ✅ Addressed | After the rewrite the algorithm IS two-step (personal → empty), so the docstring now matches. |
| Wrong `db diff` command in README | `db diff -f` shadow-DB approach failed on cross-module FKs in the original design | ✅ Addressed | README documents the working `--from=migrations --to=local` flow; still applies even though the new design no longer has cross-module FKs (kept for parity with sibling modules). |
| Teammate JWT-policy follow-up | Original PR raised whether to migrate the teammate policy to `jwt_has_project_permission` | N/A | Teammate policy no longer exists — Project Search is personal-only. |
