### PR TITLE
CA-648 feat: add user_cost_estimates sync stream and corresponding mi…

### DIFF
--- a/powersync/sync-config.yaml
+++ b/powersync/sync-config.yaml
@@ -56,3 +56,38 @@ streams:
              joined_at, membership_status
       FROM project_members
       WHERE user_id = auth.parameter('$.app_metadata.internal_user_id')
+
+  # ── 4. COST ESTIMATES ───────────────────────────────────────────
+  # Gated by the 'get_cost_estimations' permission to mirror the RLS
+  # policy in 20260313081637_migrate_cost_estimates_rls_to_jwt.sql.
+  # PowerSync bypasses Postgres RLS, so the sync rule MUST enforce
+  # the same permission check the API enforces — otherwise users
+  # without the permission would still receive the rows.
+  #
+  # Soft-deleted rows (deleted_at IS NOT NULL) are excluded.
+  user_cost_estimates:
+    auto_subscribe: false  # on-demand: app subscribes when user enters cost estimation feature to avoid evaluating the 4-table CTE join on every connection startup
+    with:
+      cost_estimate_projects: |
+        SELECT DISTINCT pm.project_id AS id
+        FROM project_members pm
+        INNER JOIN projects p ON p.id = pm.project_id
+        INNER JOIN role_permissions rp ON rp.role_id = pm.role_id
+        INNER JOIN permissions perm ON perm.id = rp.permission_id
+        WHERE pm.user_id = auth.parameter('$.app_metadata.internal_user_id')
+          AND pm.membership_status = 'joined'
+          AND p.project_status = 'active'
+          AND perm.permission_key = 'get_cost_estimations'
+    # deleted_at intentionally excluded: used only in WHERE filter; soft-deleted rows disappear from the client stream entirely
+    query: |
+      SELECT id, project_id, estimate_name, estimate_description,
+             creator_user_id, markup_type,
+             overall_markup_value_type, overall_markup_value,
+             material_markup_value_type, material_markup_value,
+             labor_markup_value_type, labor_markup_value,
+             equipment_markup_value_type, equipment_markup_value,
+             total_cost, is_locked, locked_by_user_id, locked_at,
+             created_at, updated_at
+      FROM cost_estimates
+      WHERE project_id IN (SELECT id FROM cost_estimate_projects)
+        AND deleted_at IS NULL

--- a/supabase/migrations/20260520000000_add_cost_estimates_to_powersync.sql
+++ b/supabase/migrations/20260520000000_add_cost_estimates_to_powersync.sql
@@ -1,0 +1,26 @@
+-- Add cost_estimates (and permission lookup tables) to PowerSync publication
+--
+-- The `user_cost_estimates` sync stream in powersync/sync-config.yaml mirrors
+-- the RLS policy from 20260313081637_migrate_cost_estimates_rls_to_jwt.sql
+-- (gated by the 'get_cost_estimations' permission). PowerSync replicates
+-- around Postgres RLS, so the sync rule MUST enforce the same permission
+-- check the API enforces.
+--
+-- The sync rule joins role_permissions and permissions inside a CTE to find
+-- which projects grant the user 'get_cost_estimations'. PowerSync evaluates
+-- sync rules against replicated state, so those tables also need to be in
+-- the publication. They are NOT exposed to clients — no sync stream selects
+-- from them; they exist only to evaluate the cost_estimates CTE.
+--
+-- Rollback (manual; Supabase migrations are append-only):
+--   ALTER PUBLICATION powersync DROP TABLE
+--     public.cost_estimates,
+--     public.role_permissions,
+--     public.permissions;
+--
+-- After dropping, restart the PowerSync replicator so it stops streaming.
+
+ALTER PUBLICATION powersync ADD TABLE
+  public.cost_estimates,
+  public.role_permissions,
+  public.permissions;


### PR DESCRIPTION
# PR Review: feat/cost-estimaation-syncc → master

**Reviewed by:** Claude  
**Date:** Fri May 22 2026  
**PR Size:** ~60 lines of production code → **S (Small)** ✅

---

---

## 2. REVIEW SUMMARY TABLE

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| Non-idempotent publication migration | `ALTER PUBLICATION powersync ADD TABLE` will error if any table is already in the publication. No `IF NOT EXISTS` exists in Postgres for this statement. |  | Idempotency is guaranteed by Supabase's migration runner `supabase_migrations.schema_migrations` this SQL runs exactly once per environment. |
| Column list not verified against schema | The explicit column SELECT in `sync-config.yaml` should be cross-checked against `01_table.sql` to confirm no columns have been added since the list was written.  | ✅ |  |