### PR TITLE
CA-252: fix(rls): add public SELECT policy for tags reference table

### DIFF
--- a/supabase/migrations/20260611223604_34_tags_select_rls_policy.sql
+++ b/supabase/migrations/20260611223604_34_tags_select_rls_policy.sql
@@ -5,6 +5,7 @@
 -- Public SELECT Policy
 -- Tags are reference data used for search filtering; anyone can read them.
 
+DROP POLICY IF EXISTS "tags_select_public" ON "public"."tags";
 CREATE POLICY "tags_select_public" ON "public"."tags" FOR SELECT USING (true);
 
 -- No INSERT/UPDATE/DELETE policies defined.

--- a/supabase/migrations/20260611223604_34_tags_select_rls_policy.sql
+++ b/supabase/migrations/20260611223604_34_tags_select_rls_policy.sql
@@ -1,0 +1,12 @@
+-- Tags RLS Policies
+
+-- RLS is already enabled for "tags" (see 20250514131510_enable_rls.sql).
+
+-- Public SELECT Policy
+-- Tags are reference data used for search filtering; anyone can read them.
+
+CREATE POLICY "tags_select_public" ON "public"."tags" FOR SELECT USING (true);
+
+-- No INSERT/UPDATE/DELETE policies defined.
+-- Write access is intentionally restricted to service_role / migrations only,
+-- matching the professional_roles reference-data pattern.

--- a/supabase/schemas/core/tags/01_rls.sql
+++ b/supabase/schemas/core/tags/01_rls.sql
@@ -1,0 +1,12 @@
+-- Tags RLS Policies
+
+-- RLS is already enabled for "tags" (see 20250514131510_enable_rls.sql).
+
+-- Public SELECT Policy
+-- Tags are reference data used for search filtering; anyone can read them.
+
+CREATE POLICY "tags_select_public" ON "public"."tags" FOR SELECT USING (true);
+
+-- No INSERT/UPDATE/DELETE policies defined.
+-- Write access is intentionally restricted to service_role / migrations only,
+-- matching the professional_roles reference-data pattern.

--- a/supabase/schemas/core/tags/01_table.sql
+++ b/supabase/schemas/core/tags/01_table.sql
@@ -1,0 +1,23 @@
+-- Tags Table
+-- Reference data used for search filtering
+
+CREATE TABLE IF NOT EXISTS "public"."tags" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "name" character varying(100) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."tags" OWNER TO "postgres";
+
+
+-- Primary Key
+
+ALTER TABLE ONLY "public"."tags"
+    ADD CONSTRAINT "tags_pkey" PRIMARY KEY ("id");
+
+
+-- Unique Constraints
+
+ALTER TABLE ONLY "public"."tags"
+    ADD CONSTRAINT "tags_name_key" UNIQUE ("name");

--- a/supabase/schemas/core/tags/02_indexes.sql
+++ b/supabase/schemas/core/tags/02_indexes.sql
@@ -1,0 +1,2 @@
+-- Tags Indexes
+-- No additional indexes defined beyond primary key and unique constraint

--- a/supabase/schemas/core/tags/03_rls.sql
+++ b/supabase/schemas/core/tags/03_rls.sql
@@ -5,6 +5,7 @@
 -- Public SELECT Policy
 -- Tags are reference data used for search filtering; anyone can read them.
 
+DROP POLICY IF EXISTS "tags_select_public" ON "public"."tags";
 CREATE POLICY "tags_select_public" ON "public"."tags" FOR SELECT USING (true);
 
 -- No INSERT/UPDATE/DELETE policies defined.


### PR DESCRIPTION
## Summary

The `tags` table (created in `20250514010735_06_tags.sql`) has RLS enabled via `20250514131510_enable_rls.sql` but **no policy was ever defined**, so authenticated client reads silently return zero rows.

The Flutter app is about to start reading this table — ripplearc/construculator-app#345 (CA-252, `TagRepository`) and ripplearc/construculator-app#346 (CA-638, Tags filter sheet) — and without this policy the tag filter UI will always show an empty list.

This adds a public SELECT policy following the exact `professional_roles_select_public` reference-data pattern: read-only for clients, writes restricted to service_role/migrations.

## Changes

- `supabase/schemas/core/tags/01_rls.sql` — declarative policy file
- `supabase/migrations/<ts>_34_tags_select_rls_policy.sql` — migration

## Testing

Policy mirrors `professional_roles` (`supabase/schemas/core/professional_roles/03_rls.sql`). After applying, `select * from tags` as an authenticated user returns rows.

## CI note

> [!NOTE]
> The `database_tests` failure on this PR is **not caused by these changes** — it's a breaking change in Supabase CLI v2.106.0 (released after the last green build) that revokes the default Data API grants our schema relied on. Confirmed via no-op control #40; root cause and fix in #41 (stopgap) / [CA-729](https://ripplearc.youtrack.cloud/issue/CA-729) (permanent explicit GRANTs). Re-run checks after #41 merges.