### PR TITLE
test: CI environment check (no-op) — do not merge

### DIFF
--- a/supabase/tests/database/core_schema_smoke_test.sql
+++ b/supabase/tests/database/core_schema_smoke_test.sql
@@ -32,3 +32,4 @@ SELECT has_index('public', 'project_members','project_user_membership_uq', ARRAY
 
 select * from finish();
 rollback;
+-- CI environment check (no-op)


### PR DESCRIPTION
No-op SQL comment to check whether database_tests fails on unchanged master (suspect: supabase-cli 'latest' regression). Will close after the run.