### PR TITLE
CA-752: fix(search): auto-update projects.updated_at on edits

### DIFF
--- a/supabase/migrations/20260624191158_35_projects_updated_at_trigger.sql
+++ b/supabase/migrations/20260624191158_35_projects_updated_at_trigger.sql
@@ -1,0 +1,25 @@
+-- CA-752: projects.updated_at was never bumped on UPDATE — there is no
+-- trigger maintaining it, unlike cost_estimates. Deploys the shared
+-- set_current_timestamp_updated_at() trigger function (already documented
+-- in supabase/schemas/_shared/01_functions.sql for reuse across tables,
+-- but never actually migrated) and attaches it to projects.
+-- https://ripplearc.youtrack.cloud/issue/CA-752
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+    RETURNS TRIGGER
+    LANGUAGE "plpgsql"
+    AS $$
+BEGIN
+  NEW.updated_at = "now"();
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."set_current_timestamp_updated_at"() IS 'Shared trigger function. Sets updated_at to now() on any BEFORE UPDATE trigger. Safe for use across all tables with an updated_at column.';
+
+CREATE OR REPLACE TRIGGER "trigger_update_projects_updated_at"
+    BEFORE UPDATE ON "public"."projects"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."set_current_timestamp_updated_at"();

--- a/supabase/schemas/core/projects/04_triggers.sql
+++ b/supabase/schemas/core/projects/04_triggers.sql
@@ -1,0 +1,8 @@
+-- Projects Triggers
+
+-- Update Timestamp
+-- Automatically updates updated_at column on row modification
+CREATE OR REPLACE TRIGGER "trigger_update_projects_updated_at"
+    BEFORE UPDATE ON "public"."projects"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."set_current_timestamp_updated_at"();

--- a/supabase/schemas/core/projects/README.md
+++ b/supabase/schemas/core/projects/README.md
@@ -1,0 +1,35 @@
+# Projects Module
+
+## Overview
+
+The `projects` table is the core unit of work in the application — every cost estimate, search result, and team membership is scoped to a project. The table itself and its indexes/RLS policies predate this `schemas/` folder and have not yet been backfilled here (see Scope below); only the `updated_at` trigger introduced in CA-752 is documented in this module so far.
+
+## Table Structure (for reference — not yet backfilled into this folder)
+
+- `id` - UUID primary key
+- `project_name` - Project display name (required)
+- `description` - Optional free-text description
+- `creator_user_id` - FK to `users.id`
+- `owning_company_id` - FK to `companies.id`
+- `export_folder_link`, `export_storage_provider` - Export destination metadata
+- `created_at`, `updated_at` - Timestamps
+- `project_status` - `project_status_enum`
+
+Defined in migration `20250514093706_12_projects.sql`. RLS policies are defined separately in `20251203040526_RLS_06_projects_rules.sql`.
+
+## Triggers
+
+### `trigger_update_projects_updated_at` — `BEFORE UPDATE`
+
+Sets `updated_at = now()` on every row update via the shared `public.set_current_timestamp_updated_at()` function (defined in `supabase/schemas/_shared/01_functions.sql`, also used by `users`, `companies`, `professional_roles`).
+
+**Why this was added (CA-752):** before this trigger existed, `projects.updated_at` was never bumped on edit — there was no mechanism maintaining it, unlike `cost_estimates`, which has its own permission-checking trigger that also sets `updated_at`. Any feature relying on `projects.updated_at` to mean "last modified" (e.g. the `global_search` date-range filter) would have been filtering on a column frozen at row creation.
+
+## Scope
+
+This module currently only documents the trigger added in CA-752. The table definition, indexes, and RLS policies that already exist in `supabase/migrations/` have not yet been backfilled into `01_table.sql`/`02_indexes.sql`/`03_rls.sql` here — that backfill is out of scope for CA-752 and should be done as its own follow-up if/when this module needs full parity with `companies`/`users`/`professional_roles`.
+
+## Related Tables
+
+- `cost_estimates`, `project_members`, `project_search_history` — all scoped to a project via `project_id`.
+- `companies` — a project's `owning_company_id` references this table.

--- a/supabase/tests/database/projects_updated_at_trigger_test.sql
+++ b/supabase/tests/database/projects_updated_at_trigger_test.sql
@@ -1,0 +1,52 @@
+BEGIN;
+
+-- CA-752: projects.updated_at must be auto-bumped on UPDATE.
+
+SELECT plan(2);
+
+DO $$
+DECLARE
+  v_user_id uuid := '11111111-1111-1111-1111-111111111111';
+  v_credential_id uuid := '22222222-2222-2222-2222-222222222222';
+  v_prof_role_id uuid := '55555555-5555-5555-5555-555555555555';
+  v_admin_role_id uuid := '66666666-6666-6666-6666-666666666666';
+  v_project_id uuid := '33333333-3333-3333-3333-333333333333';
+BEGIN
+  INSERT INTO professional_roles (id, name) VALUES (v_prof_role_id, 'Test Role');
+  INSERT INTO users (id, credential_id, email, first_name, last_name, professional_role, created_at, user_status, user_preferences, country_code)
+    VALUES (v_user_id, v_credential_id, 'updated_at_trigger@example.com', 'Trigger', 'Test', v_prof_role_id, now(), 'active', '{}', '+1');
+
+  INSERT INTO roles (id, role_name, level, context_type) VALUES (v_admin_role_id, 'TestAdmin', 4, 'project');
+  INSERT INTO role_permissions (role_id, permission_id)
+    SELECT v_admin_role_id, id FROM permissions WHERE permission_key IN ('view_project', 'edit_project');
+
+  INSERT INTO projects (id, project_name, creator_user_id, created_at, updated_at, project_status)
+    VALUES (v_project_id, 'trigger test project', v_user_id, now() - interval '60 days', now() - interval '60 days', 'active');
+
+  INSERT INTO project_members (project_id, user_id, role_id, membership_status, joined_at)
+    VALUES (v_project_id, v_user_id, v_admin_role_id, 'joined', now());
+END $$;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims', '{"sub": "22222222-2222-2222-2222-222222222222"}', true);
+
+UPDATE projects SET project_name = 'trigger test project (renamed)' WHERE id = '33333333-3333-3333-3333-333333333333';
+
+SELECT cmp_ok(
+  (SELECT updated_at FROM projects WHERE id = '33333333-3333-3333-3333-333333333333'),
+  '>',
+  now() - interval '1 minute',
+  'projects.updated_at trigger bumps the timestamp on UPDATE'
+);
+
+SELECT isnt(
+  (SELECT updated_at FROM projects WHERE id = '33333333-3333-3333-3333-333333333333'),
+  (SELECT created_at FROM projects WHERE id = '33333333-3333-3333-3333-333333333333'),
+  'updated_at no longer matches the original created_at after an edit'
+);
+
+RESET ROLE;
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- `projects.updated_at` was never bumped on `UPDATE` — there was no trigger maintaining it, unlike `cost_estimates`. Editing a project's name/description left `updated_at` frozen at creation time.
- Deploys `public.set_current_timestamp_updated_at()`, a shared trigger function already documented in `supabase/schemas/_shared/01_functions.sql` for reuse across tables (`users`, `companies`, `professional_roles` already reference it in their schema files) but never actually migrated, and attaches it to `projects` via `CREATE OR REPLACE TRIGGER`.
- Adds the matching `supabase/schemas/core/projects/04_triggers.sql` schema file and a `core/projects/README.md` documenting the trigger (per this repo's schema-module-doc rule; table/indexes/RLS for `projects` are not yet backfilled into `schemas/` — out of scope here, noted in the README).
- This is a prerequisite for CA-170's global search "Modified" date filter to mean anything for projects (follow-up PR #43), but is a standalone, independently-reviewable bug fix.

## Test plan
- [x] `supabase test db` — new `projects_updated_at_trigger_test.sql` passes (asserts `updated_at` is bumped past `now() - 1 minute` after an `UPDATE`, and that it no longer equals `created_at`).
- [x] Full local pgTAP suite passes with this migration applied in isolation (145/145).

## Review Summary

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| Schema doc backfill | New trigger touched `projects`, which had no `supabase/schemas/core/projects/` module or README yet | ✅ Addressed | Added `04_triggers.sql` + `README.md` scoped to the trigger; full table/indexes/RLS backfill left as a separate follow-up (noted in the README) |