### PR TITLE
CA-597: feat(search): purge orphaned search_history rows via pg_cron

### DIFF
--- a/supabase/migrations/20260714230219_38_search_history_cleanup.sql
+++ b/supabase/migrations/20260714230219_38_search_history_cleanup.sql
@@ -27,7 +27,7 @@ SET search_path = public, auth
 AS $$
 BEGIN
   -- Defense-in-depth against an authenticated Data API call. Primary access
-  -- control is the REVOKE below (anon/authenticated hold no EXECUTE); this
+  -- control is the REVOKE below (no Data API role holds EXECUTE); this
   -- guard is a second layer in case the CLI's auto_expose_new_tables grant
   -- pass re-grants EXECUTE on db reset (a repo-wide issue tracked by CA-729,
   -- affecting every function). PostgREST populates request.jwt.claims with a
@@ -64,6 +64,7 @@ purge-orphaned-search-history pg_cron job (CA-597). Not exposed via the API.';
 REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM anon;
 REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM service_role;
 GRANT EXECUTE ON FUNCTION public.purge_orphaned_search_history() TO postgres;
 
 -- ============================================================

--- a/supabase/migrations/20260714230219_38_search_history_cleanup.sql
+++ b/supabase/migrations/20260714230219_38_search_history_cleanup.sql
@@ -1,0 +1,83 @@
+-- CA-597: Purge orphaned search-history rows.
+-- search_history.user_id and project_search_history.user_id store auth.uid()
+-- with no FK to auth.users (cross-schema boundary), so rows are not
+-- cascade-deleted when a user is removed from Supabase Auth. This adds a
+-- SECURITY DEFINER purge function and a daily pg_cron job that deletes rows
+-- whose user_id no longer exists in auth.users, from both tables.
+-- https://ripplearc.youtrack.cloud/issue/CA-597
+--
+-- Hand-authored (not `supabase db diff`-generated): pg_cron objects live in
+-- the `cron` schema, which `db diff` does not track. The executable
+-- statements below mirror supabase/schemas/global_search/
+-- search_history_cleanup/ (03_functions.sql + 07_cron.sql), which remain
+-- the source of truth; only migration boilerplate (check_function_bodies)
+-- and some explanatory comments differ.
+-- (Annotated per the CA-737 precedent for annotated migrations.)
+
+set check_function_bodies = off;
+
+-- ============================================================
+-- Purge function (see search_history_cleanup/03_functions.sql).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.purge_orphaned_search_history()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+BEGIN
+  -- Defense-in-depth against an authenticated Data API call. Primary access
+  -- control is the REVOKE below (anon/authenticated hold no EXECUTE); this
+  -- guard is a second layer in case the CLI's auto_expose_new_tables grant
+  -- pass re-grants EXECUTE on db reset (a repo-wide issue tracked by CA-729,
+  -- affecting every function). PostgREST populates request.jwt.claims with a
+  -- non-empty JWT for an authenticated request; pg_cron and direct
+  -- service/psql calls never set it. This is a maintenance function that
+  -- bypasses RLS and deletes rows.
+  --
+  -- Scope note: this does not by itself stop an *anon* call (no JWT, so it
+  -- looks like the cron path) — that path is closed only by the REVOKE, same
+  -- as every other SECURITY DEFINER function in this schema.
+  IF current_setting('request.jwt.claims', true) IS NOT NULL
+     AND current_setting('request.jwt.claims', true) <> '' THEN
+    RAISE EXCEPTION 'purge_orphaned_search_history is not callable via the API'
+      USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.search_history sh
+  WHERE NOT EXISTS (
+    SELECT 1 FROM auth.users u WHERE u.id = sh.user_id
+  );
+
+  DELETE FROM public.project_search_history psh
+  WHERE NOT EXISTS (
+    SELECT 1 FROM auth.users u WHERE u.id = psh.user_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.purge_orphaned_search_history IS
+'Deletes search_history and project_search_history rows whose user_id no
+longer exists in auth.users. SECURITY DEFINER; invoked by the daily
+purge-orphaned-search-history pg_cron job (CA-597). Not exposed via the API.';
+
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_orphaned_search_history() TO postgres;
+
+-- ============================================================
+-- pg_cron schedule (see search_history_cleanup/07_cron.sql).
+-- ============================================================
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+SELECT cron.unschedule('purge-orphaned-search-history')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'purge-orphaned-search-history'
+);
+
+SELECT cron.schedule(
+  'purge-orphaned-search-history',
+  '0 3 * * *',
+  $$SELECT public.purge_orphaned_search_history();$$
+);

--- a/supabase/schemas/global_search/project_search_history/README.md
+++ b/supabase/schemas/global_search/project_search_history/README.md
@@ -50,9 +50,9 @@ Project Search history is personal — there is no teammate or cross-user visibi
 
 ### 4. Orphan Risk
 
-`user_id` has no foreign key to `auth.users` (cross-schema boundary). Rows are not cascade-deleted when a user is removed. A periodic cleanup job should purge rows where `user_id` no longer exists in `auth.users`.
+`user_id` has no foreign key to `auth.users` (cross-schema boundary). Rows are not cascade-deleted when a user is removed. This is handled by a periodic cleanup job.
 
-> **TODO ([CA-597](https://ripplearc.youtrack.cloud/issue/CA-597)):** The same orphan-cleanup ticket that covers `search_history` should also purge `project_search_history` rows whose `user_id` no longer exists in `auth.users`. Extend the cleanup job's scope when CA-597 is implemented.
+**Resolved ([CA-597](https://ripplearc.youtrack.cloud/issue/CA-597)):** The daily `purge-orphaned-search-history` `pg_cron` job (03:00 UTC) also purges `project_search_history` rows whose `user_id` no longer exists in `auth.users`, via `public.purge_orphaned_search_history()`. See the [`search_history_cleanup`](../search_history_cleanup/README.md) module.
 
 ---
 

--- a/supabase/schemas/global_search/search_history/README.md
+++ b/supabase/schemas/global_search/search_history/README.md
@@ -41,9 +41,9 @@ Project members can read each other's `search_history` rows for shared projects 
 
 ### 4. Orphan Risk
 
-`user_id` has no foreign key to `auth.users` (cross-schema boundary). Rows are not cascade-deleted when a user is removed. A periodic cleanup job should purge rows where `user_id` no longer exists in `auth.users`.
+`user_id` has no foreign key to `auth.users` (cross-schema boundary). Rows are not cascade-deleted when a user is removed. This is handled by a periodic cleanup job.
 
-> **TODO ([CA-597](https://ripplearc.youtrack.cloud/issue/CA-597)):** Implement periodic cleanup job to purge `search_history` rows where `user_id` no longer exists in `auth.users`.
+**Resolved ([CA-597](https://ripplearc.youtrack.cloud/issue/CA-597)):** A daily `pg_cron` job (`purge-orphaned-search-history`, 03:00 UTC) purges rows where `user_id` no longer exists in `auth.users`, via `public.purge_orphaned_search_history()`. See the [`search_history_cleanup`](../search_history_cleanup/README.md) module.
 
 ---
 

--- a/supabase/schemas/global_search/search_history_cleanup/03_functions.sql
+++ b/supabase/schemas/global_search/search_history_cleanup/03_functions.sql
@@ -17,9 +17,11 @@
 -- cannot see under normal privileges, and (b) bypass the per-user RLS
 -- policies on both tables (each restricts DELETE to user_id = auth.uid()).
 --
--- This function is never reachable via PostgREST: EXECUTE is revoked from
--- anon/authenticated below and granted only to the postgres role that
--- pg_cron runs as.
+-- This function is not reachable via PostgREST: EXECUTE is revoked from all
+-- Data API roles (anon/authenticated/service_role) below and granted only to
+-- the postgres role that pg_cron runs as. (The CLI's auto_expose_new_tables
+-- pass may re-grant the Data API roles on db reset — CA-729; the in-body JWT
+-- guard covers that case.)
 -- ============================================================
 CREATE OR REPLACE FUNCTION public.purge_orphaned_search_history()
 RETURNS void
@@ -29,7 +31,7 @@ SET search_path = public, auth
 AS $$
 BEGIN
   -- Defense-in-depth against an authenticated Data API call. Primary access
-  -- control is the REVOKE below (anon/authenticated hold no EXECUTE); this
+  -- control is the REVOKE below (no Data API role holds EXECUTE); this
   -- guard is a second layer in case the CLI's auto_expose_new_tables grant
   -- pass re-grants EXECUTE on db reset (a repo-wide issue tracked by CA-729,
   -- affecting every function). PostgREST populates request.jwt.claims with a
@@ -68,4 +70,5 @@ purge-orphaned-search-history pg_cron job (CA-597). Not exposed via the API.';
 REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM anon;
 REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM service_role;
 GRANT EXECUTE ON FUNCTION public.purge_orphaned_search_history() TO postgres;

--- a/supabase/schemas/global_search/search_history_cleanup/03_functions.sql
+++ b/supabase/schemas/global_search/search_history_cleanup/03_functions.sql
@@ -1,0 +1,71 @@
+-- Functions for the search_history_cleanup module (CA-597).
+--
+-- Purges orphaned rows from the two search-history tables. Both tables store
+-- auth.uid() in user_id with NO foreign key to auth.users (cross-schema
+-- boundary), so rows are not cascade-deleted when a user is removed from
+-- Supabase Auth. This function reclaims those orphaned rows; a pg_cron job
+-- (see 07_cron.sql) invokes it on a daily schedule.
+
+-- ============================================================
+-- purge_orphaned_search_history()
+--
+-- Deletes rows in search_history and project_search_history whose user_id
+-- no longer exists in auth.users. Rows belonging to active users are never
+-- touched.
+--
+-- SECURITY DEFINER: required to (a) read auth.users, which the cron role
+-- cannot see under normal privileges, and (b) bypass the per-user RLS
+-- policies on both tables (each restricts DELETE to user_id = auth.uid()).
+--
+-- This function is never reachable via PostgREST: EXECUTE is revoked from
+-- anon/authenticated below and granted only to the postgres role that
+-- pg_cron runs as.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.purge_orphaned_search_history()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+BEGIN
+  -- Defense-in-depth against an authenticated Data API call. Primary access
+  -- control is the REVOKE below (anon/authenticated hold no EXECUTE); this
+  -- guard is a second layer in case the CLI's auto_expose_new_tables grant
+  -- pass re-grants EXECUTE on db reset (a repo-wide issue tracked by CA-729,
+  -- affecting every function). PostgREST populates request.jwt.claims with a
+  -- non-empty JWT for an authenticated request; pg_cron and direct
+  -- service/psql calls never set it. This is a maintenance function that
+  -- bypasses RLS and deletes rows.
+  --
+  -- Scope note: this does not by itself stop an *anon* call (no JWT, so it
+  -- looks like the cron path) — that path is closed only by the REVOKE, same
+  -- as every other SECURITY DEFINER function in this schema.
+  IF current_setting('request.jwt.claims', true) IS NOT NULL
+     AND current_setting('request.jwt.claims', true) <> '' THEN
+    RAISE EXCEPTION 'purge_orphaned_search_history is not callable via the API'
+      USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.search_history sh
+  WHERE NOT EXISTS (
+    SELECT 1 FROM auth.users u WHERE u.id = sh.user_id
+  );
+
+  DELETE FROM public.project_search_history psh
+  WHERE NOT EXISTS (
+    SELECT 1 FROM auth.users u WHERE u.id = psh.user_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.purge_orphaned_search_history IS
+'Deletes search_history and project_search_history rows whose user_id no
+longer exists in auth.users. SECURITY DEFINER; invoked by the daily
+purge-orphaned-search-history pg_cron job (CA-597). Not exposed via the API.';
+
+-- Lock down execution: only the postgres role (which pg_cron runs as) may
+-- invoke this. Revoke the default PUBLIC grant and the Data API roles.
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.purge_orphaned_search_history() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_orphaned_search_history() TO postgres;

--- a/supabase/schemas/global_search/search_history_cleanup/07_cron.sql
+++ b/supabase/schemas/global_search/search_history_cleanup/07_cron.sql
@@ -1,0 +1,24 @@
+-- Scheduled cleanup for the search_history_cleanup module (CA-597).
+--
+-- Enables pg_cron and registers a daily job that purges orphaned rows from
+-- the two search-history tables via public.purge_orphaned_search_history().
+--
+-- Note: pg_cron objects live in the `cron` schema, which `supabase db diff`
+-- does not track. The statements below are the authoritative source and are
+-- carried into the generated migration by hand (see the migration header).
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Idempotent (re)registration: unschedule any existing job with this name
+-- before scheduling, so re-applying this file never errors or duplicates.
+SELECT cron.unschedule('purge-orphaned-search-history')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'purge-orphaned-search-history'
+);
+
+-- Daily at 03:00 UTC (low-traffic window).
+SELECT cron.schedule(
+  'purge-orphaned-search-history',
+  '0 3 * * *',
+  $$SELECT public.purge_orphaned_search_history();$$
+);

--- a/supabase/schemas/global_search/search_history_cleanup/README.md
+++ b/supabase/schemas/global_search/search_history_cleanup/README.md
@@ -17,7 +17,7 @@ Deletes rows from `search_history` and `project_search_history` where `user_id` 
 - **`SECURITY DEFINER`** — required to read `auth.users` (invisible to the cron role under normal privileges) and to bypass the per-user RLS `DELETE` policies on both tables (each restricts deletes to `user_id = auth.uid()`).
 - **`SET search_path = public, auth`** — pinned, per repo convention.
 - Uses `NOT EXISTS` anti-joins against `auth.users(id)` (its PK). Note the plan is a seq scan + hash anti-join — every row must be checked, so the `user_id` indexes do **not** accelerate this query. That is fine at these tables' expected size (bounded by users × distinct terms); if they ever grow large, batch the DELETE.
-- **Not exposed via the API.** `EXECUTE` is revoked from `PUBLIC`, `anon`, and `authenticated`, and granted only to `postgres` (the role `pg_cron` runs as) — this REVOKE is the primary access control. As defense-in-depth against an *authenticated* call, the body also rejects any request carrying a non-empty `request.jwt.claims` JWT (which PostgREST sets for authenticated requests and `pg_cron` never does) with `42501`. This second layer matters because the CLI's `auto_expose_new_tables` grant pass can re-grant `EXECUTE` to the Data API roles on `db reset` (a repo-wide issue tracked by [CA-729](https://ripplearc.youtrack.cloud/issue/CA-729), affecting every function). Note the guard does not by itself stop an *anon* call (no JWT — indistinguishable from the cron path); that path relies on the REVOKE, as with every other `SECURITY DEFINER` function in this schema.
+- **Not exposed via the API.** `EXECUTE` is revoked from `PUBLIC` and all three Data API roles (`anon`, `authenticated`, `service_role`), and granted only to `postgres` (the role `pg_cron` runs as) — this REVOKE is the primary access control. Note the grant list is only guaranteed at migration time: while `auto_expose_new_tables` is on, the CLI's grant pass can re-grant `EXECUTE` to the Data API roles on `db reset` (a repo-wide issue tracked by [CA-729](https://ripplearc.youtrack.cloud/issue/CA-729), affecting every function). As defense-in-depth for that case, the body also rejects any request carrying a non-empty `request.jwt.claims` JWT (which PostgREST sets for authenticated requests and `pg_cron` never does) with `42501`. The guard does not by itself stop an *anon* call (no JWT — indistinguishable from the cron path); that path relies on the REVOKE, as with every other `SECURITY DEFINER` function in this schema.
 
 ---
 
@@ -52,6 +52,7 @@ To change cadence, edit the cron expression in `07_cron.sql` and regenerate the 
 **pgTAP** — `supabase/tests/functions/purge_orphaned_search_history_test.sql`:
 - Seeds `auth.users` with one active user and inserts rows for both that user and an orphan `user_id` into both tables.
 - Calls `purge_orphaned_search_history()` and asserts orphan rows are gone from both tables while the active user's rows survive.
+- Asserts the `purge-orphaned-search-history` job is registered in `cron.job` (the one piece of wiring `supabase db diff` cannot verify).
 
 Run with `supabase test db`.
 

--- a/supabase/schemas/global_search/search_history_cleanup/README.md
+++ b/supabase/schemas/global_search/search_history_cleanup/README.md
@@ -1,0 +1,71 @@
+# Global Search — `search_history_cleanup` Module
+
+## Overview
+
+Both `search_history.user_id` and `project_search_history.user_id` store `auth.uid()` with **no foreign key** to `auth.users` (cross-schema boundary). When a user is deleted from Supabase Auth, their rows in these tables are not cascade-deleted and become orphaned — they accumulate indefinitely and pollute teammate suggestion queries.
+
+This module implements the periodic cleanup called for by [CA-597](https://ripplearc.youtrack.cloud/issue/CA-597): a `pg_cron` job that deletes rows whose `user_id` no longer exists in `auth.users`, from **both** tables, without touching rows of active users.
+
+---
+
+## Function
+
+### `public.purge_orphaned_search_history()` → `void`
+
+Deletes rows from `search_history` and `project_search_history` where `user_id` has no matching row in `auth.users`.
+
+- **`SECURITY DEFINER`** — required to read `auth.users` (invisible to the cron role under normal privileges) and to bypass the per-user RLS `DELETE` policies on both tables (each restricts deletes to `user_id = auth.uid()`).
+- **`SET search_path = public, auth`** — pinned, per repo convention.
+- Uses `NOT EXISTS` anti-joins against `auth.users(id)` (its PK). Note the plan is a seq scan + hash anti-join — every row must be checked, so the `user_id` indexes do **not** accelerate this query. That is fine at these tables' expected size (bounded by users × distinct terms); if they ever grow large, batch the DELETE.
+- **Not exposed via the API.** `EXECUTE` is revoked from `PUBLIC`, `anon`, and `authenticated`, and granted only to `postgres` (the role `pg_cron` runs as) — this REVOKE is the primary access control. As defense-in-depth against an *authenticated* call, the body also rejects any request carrying a non-empty `request.jwt.claims` JWT (which PostgREST sets for authenticated requests and `pg_cron` never does) with `42501`. This second layer matters because the CLI's `auto_expose_new_tables` grant pass can re-grant `EXECUTE` to the Data API roles on `db reset` (a repo-wide issue tracked by [CA-729](https://ripplearc.youtrack.cloud/issue/CA-729), affecting every function). Note the guard does not by itself stop an *anon* call (no JWT — indistinguishable from the cron path); that path relies on the REVOKE, as with every other `SECURITY DEFINER` function in this schema.
+
+---
+
+## Schedule
+
+`pg_cron` job **`purge-orphaned-search-history`**, defined in `07_cron.sql`:
+
+| Setting | Value |
+|---|---|
+| Schedule | `0 3 * * *` — daily at 03:00 UTC (low-traffic window) |
+| Command | `SELECT public.purge_orphaned_search_history();` |
+
+Registration is idempotent: the job is unscheduled (if present) before being (re)scheduled, so re-applying the schema never errors or creates duplicates.
+
+To change cadence, edit the cron expression in `07_cron.sql` and regenerate the migration.
+
+---
+
+## Files
+
+| File | Content |
+|---|---|
+| `03_functions.sql` | `purge_orphaned_search_history()` + `GRANT`/`REVOKE`. |
+| `07_cron.sql` | `CREATE EXTENSION IF NOT EXISTS pg_cron` + idempotent `cron.schedule(...)`. |
+
+> **Migration note:** `pg_cron` objects live in the `cron` schema, which `supabase db diff` does not track. The `07_cron.sql` statements are the authoritative source and are carried into the generated migration by hand (annotated in the migration header, per the CA-737 precedent for annotated generated migrations).
+
+---
+
+## Verification
+
+**pgTAP** — `supabase/tests/functions/purge_orphaned_search_history_test.sql`:
+- Seeds `auth.users` with one active user and inserts rows for both that user and an orphan `user_id` into both tables.
+- Calls `purge_orphaned_search_history()` and asserts orphan rows are gone from both tables while the active user's rows survive.
+
+Run with `supabase test db`.
+
+**Manual (local):**
+```sql
+-- Confirm the job registered:
+SELECT jobname, schedule, command FROM cron.job;
+-- Run the purge directly:
+SELECT public.purge_orphaned_search_history();
+```
+
+---
+
+## Related Tables
+
+- `search_history` — Global Search history (see sibling [`search_history`](../search_history/README.md) module).
+- `project_search_history` — Project Search history (see sibling [`project_search_history`](../project_search_history/README.md) module).

--- a/supabase/tests/functions/purge_orphaned_search_history_test.sql
+++ b/supabase/tests/functions/purge_orphaned_search_history_test.sql
@@ -1,0 +1,84 @@
+BEGIN;
+
+-- Tests for CA-597: public.purge_orphaned_search_history() deletes rows in
+-- search_history and project_search_history whose user_id no longer exists in
+-- auth.users, while leaving rows of active users untouched.
+
+SELECT plan(6);
+
+SELECT has_function(
+  'public',
+  'purge_orphaned_search_history',
+  ARRAY[]::text[],
+  'purge_orphaned_search_history() exists with no arguments'
+);
+
+-- API guard: a call carrying a JWT-claims setting (as PostgREST always sends)
+-- is rejected, even if EXECUTE was re-granted to authenticated on db reset.
+SELECT set_config('request.jwt.claims',
+  '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+SELECT throws_ok(
+  $$ SELECT public.purge_orphaned_search_history() $$,
+  '42501',
+  'purge_orphaned_search_history is not callable via the API',
+  'Call with request.jwt.claims set (Data API path) is rejected'
+);
+SELECT set_config('request.jwt.claims', NULL, true);
+
+DO $$
+DECLARE
+  v_active_user uuid := '11111111-1111-1111-1111-111111111111';
+  v_orphan_user uuid := '99999999-9999-9999-9999-999999999999';
+BEGIN
+  -- One active user exists in auth; the orphan user_id never does.
+  INSERT INTO auth.users (id) VALUES (v_active_user);
+
+  -- Global Search history: one active row, one orphan row.
+  INSERT INTO public.search_history (user_id, search_term, scope, has_results)
+    VALUES (v_active_user, 'active term', 'dashboard', true);
+  INSERT INTO public.search_history (user_id, search_term, scope, has_results)
+    VALUES (v_orphan_user, 'orphan term', 'dashboard', true);
+
+  -- Project Search history: one active row, one orphan row.
+  INSERT INTO public.project_search_history (user_id, search_term, has_results)
+    VALUES (v_active_user, 'active project term', true);
+  INSERT INTO public.project_search_history (user_id, search_term, has_results)
+    VALUES (v_orphan_user, 'orphan project term', true);
+END $$;
+
+-- Run the purge.
+SELECT public.purge_orphaned_search_history();
+
+-- search_history: orphan gone, active preserved.
+SELECT is(
+  (SELECT count(*)::int FROM public.search_history
+   WHERE user_id = '99999999-9999-9999-9999-999999999999'),
+  0,
+  'search_history: orphan rows are purged'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM public.search_history
+   WHERE user_id = '11111111-1111-1111-1111-111111111111'),
+  1,
+  'search_history: active user rows are untouched'
+);
+
+-- project_search_history: orphan gone, active preserved.
+SELECT is(
+  (SELECT count(*)::int FROM public.project_search_history
+   WHERE user_id = '99999999-9999-9999-9999-999999999999'),
+  0,
+  'project_search_history: orphan rows are purged'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM public.project_search_history
+   WHERE user_id = '11111111-1111-1111-1111-111111111111'),
+  1,
+  'project_search_history: active user rows are untouched'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/functions/purge_orphaned_search_history_test.sql
+++ b/supabase/tests/functions/purge_orphaned_search_history_test.sql
@@ -4,13 +4,22 @@ BEGIN;
 -- search_history and project_search_history whose user_id no longer exists in
 -- auth.users, while leaving rows of active users untouched.
 
-SELECT plan(6);
+SELECT plan(7);
 
 SELECT has_function(
   'public',
   'purge_orphaned_search_history',
   ARRAY[]::text[],
   'purge_orphaned_search_history() exists with no arguments'
+);
+
+-- The pg_cron job registered. The cron schema is not tracked by
+-- `supabase db diff`, so this is the only automated check of the wiring.
+SELECT is(
+  (SELECT count(*)::int FROM cron.job
+   WHERE jobname = 'purge-orphaned-search-history'),
+  1,
+  'pg_cron job purge-orphaned-search-history is registered'
 );
 
 -- API guard: a call carrying a JWT-claims setting (as PostgREST always sends)


### PR DESCRIPTION
## What

Adds a periodic cleanup that deletes orphaned rows from `search_history` and `project_search_history`. Both tables store `auth.uid()` in `user_id` with **no FK** to `auth.users` (cross-schema boundary), so rows are never cascade-deleted when a user is removed from Supabase Auth and accumulate as orphans (CA-597).

## How

- **`public.purge_orphaned_search_history()`** — `SECURITY DEFINER`, `search_path` pinned to `public, auth`. Anti-joins (`NOT EXISTS`) both tables against `auth.users(id)` and deletes rows with no matching auth user. `SECURITY DEFINER` is needed to read `auth.users` and to bypass the per-user RLS `DELETE` policies.
- **Lockdown** — `EXECUTE` revoked from `PUBLIC`/`anon`/`authenticated`, granted only to `postgres`. As defense-in-depth, the body rejects any call carrying `request.jwt.claims` (which PostgREST always sets and `pg_cron` never does) with `42501`, so it stays uncallable via the Data API even if `auto_expose_new_tables` re-grants `EXECUTE` on `db reset` (see `config.toml` / CA-729).
- **Schedule** — `pg_cron` job `purge-orphaned-search-history`, daily at 03:00 UTC, registered idempotently (unschedule-if-exists → schedule).
- **Scope** — covers both `search_history` and `project_search_history`; the latter's README already pointed CA-597 at it.
- **Docs** — the Orphan-Risk `TODO (CA-597)` in both module READMEs is replaced with an implemented-solution description; new `search_history_cleanup` module README added.

## Layout

New declarative module `supabase/schemas/global_search/search_history_cleanup/` (`03_functions.sql`, `07_cron.sql`, `README.md`) + generated migration `20260714230219_38_search_history_cleanup.sql`. The migration is hand-authored and annotated because `pg_cron` objects live in the `cron` schema, which `supabase db diff` does not track; the `07_cron.sql` statements remain the source of truth.

## Verification

pgTAP test `supabase/tests/functions/purge_orphaned_search_history_test.sql` (6 tests): asserts orphan rows are purged from **both** tables, active-user rows are untouched in both, and the API guard rejects a call carrying `request.jwt.claims`. All 6 pass locally; the migration applies cleanly and idempotently.