### PR TITLE
CA-596: feat(search): apply filter_by_tag to global_search via project_tags

### DIFF
--- a/supabase/migrations/20260724074549_39_global_search_tag_filter.sql
+++ b/supabase/migrations/20260724074549_39_global_search_tag_filter.sql
@@ -1,58 +1,20 @@
--- Functions for the Global Search feature (dashboard-wide search across
--- projects, cost estimates, and members).
+-- CA-596: Apply global_search's filter_by_tag param to the projects
+-- result. Introduces the project_tags pivot (projects <-> tags;
+-- previously no project-to-tag association existed) and filters the
+-- projects block via an EXISTS probe matching tags.name exactly.
+-- NULL filter_by_tag means "no tag filter" (existing behavior).
+-- SELECT on project_tags follows project visibility
+-- (user_has_project_permission), so tag assignments of invisible
+-- projects never surface; no write policies are defined (writes are
+-- service_role / migrations only, matching the tags pattern).
+-- Generated via `supabase db diff --from=migrations --to=local` from
+-- supabase/schemas/core/project_tags/ and
+-- supabase/schemas/global_search/global_search/03_functions.sql per
+-- that module's README workflow.
+-- https://ripplearc.youtrack.cloud/issue/CA-596
 
--- ============================================================
--- global_search RPC
---
--- Parameters:
---   query                 text     — required, matched against project_name/
---                                     description, estimate_name/description,
---                                     and member first_name/last_name/email.
---   filter_by_tag         text     — restricts the projects result to
---                                     projects linked (via project_tags) to
---                                     a tag with this exact name. NULL means
---                                     no tag filter. Applies only to
---                                     projects; estimations and members are
---                                     unaffected.
---   filter_by_date_from   timestamptz — inclusive lower bound on updated_at.
---   filter_by_date_to     timestamptz — inclusive upper bound on updated_at.
---   filter_by_owners      uuid[]   — restricts projects/estimates to rows
---                                     whose creator_user_id is in the array.
---                                     NULL or an empty array means "no owner
---                                     filter" (an empty array is the natural
---                                     "no owners selected" client state and
---                                     must not silently match zero rows).
---   scope                 text     — one of 'dashboard', 'estimation',
---                                     'member', or NULL for all.
---   projects_offset, estimations_offset, members_offset, "limit" — pagination.
---
--- Returns: jsonb { projects: [...], estimations: [...], members: [...] }
---
--- Date range filter:
---   Applies to projects.updated_at and cost_estimates.updated_at as an
---   inclusive range. Either bound may be NULL to leave that side
---   unbounded. An inverted range (filter_by_date_from > filter_by_date_to)
---   raises a 22023 error rather than silently returning no rows.
---
--- SECURITY INVOKER: relies on RLS on projects/cost_estimates/project_members/
--- users for row visibility — this function does not bypass RLS.
---
--- Privacy: the members result selects only u.id, first_name, last_name,
--- professional_role, profile_photo_url. Never select users.credential_id
--- here (prior review caught credential_id leakage on this exact RPC).
--- ============================================================
-CREATE OR REPLACE FUNCTION public.global_search(
-  query text,
-  filter_by_tag text DEFAULT NULL::text,
-  filter_by_date_from timestamp with time zone DEFAULT NULL::timestamp with time zone,
-  filter_by_date_to timestamp with time zone DEFAULT NULL::timestamp with time zone,
-  filter_by_owners uuid[] DEFAULT NULL::uuid[],
-  scope text DEFAULT NULL::text,
-  projects_offset integer DEFAULT 0,
-  estimations_offset integer DEFAULT 0,
-  members_offset integer DEFAULT 0,
-  "limit" integer DEFAULT 20
-)
+SET check_function_bodies = false;
+CREATE OR REPLACE FUNCTION public.global_search(query text, filter_by_tag text DEFAULT NULL::text, filter_by_date_from timestamp with time zone DEFAULT NULL::timestamp with time zone, filter_by_date_to timestamp with time zone DEFAULT NULL::timestamp with time zone, filter_by_owners uuid[] DEFAULT NULL::uuid[], scope text DEFAULT NULL::text, projects_offset integer DEFAULT 0, estimations_offset integer DEFAULT 0, members_offset integer DEFAULT 0, "limit" integer DEFAULT 20)
  RETURNS jsonb
  LANGUAGE plpgsql
  SET search_path TO 'public'
@@ -183,5 +145,15 @@ BEGIN
   );
 
 END;
-$function$
-;
+$function$;
+CREATE TABLE public.project_tags (id uuid DEFAULT gen_random_uuid() NOT NULL, project_id uuid NOT NULL, tag_id uuid NOT NULL, applied_at timestamp with time zone DEFAULT now() NOT NULL);
+ALTER TABLE public.project_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_tags ADD CONSTRAINT project_tags_pkey PRIMARY KEY (id);
+ALTER TABLE public.project_tags ADD CONSTRAINT project_tags_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+ALTER TABLE public.project_tags ADD CONSTRAINT project_tags_tag_id_fkey FOREIGN KEY (tag_id) REFERENCES public.tags(id) ON DELETE CASCADE;
+GRANT ALL ON public.project_tags TO anon;
+GRANT ALL ON public.project_tags TO authenticated;
+GRANT ALL ON public.project_tags TO service_role;
+CREATE INDEX project_tags_tag_id_idx ON public.project_tags (tag_id);
+CREATE UNIQUE INDEX project_tag_uq ON public.project_tags (project_id, tag_id);
+CREATE POLICY project_tags_select_policy ON public.project_tags FOR SELECT USING (public.user_has_project_permission(project_id, 'view_project'::text, auth.uid()));

--- a/supabase/schemas/core/project_tags/01_table.sql
+++ b/supabase/schemas/core/project_tags/01_table.sql
@@ -1,0 +1,30 @@
+-- Project Tags Table
+-- Many-to-many pivot linking tags to projects, mirroring the session_tags
+-- pivot that links tags to calculation sessions.
+
+CREATE TABLE IF NOT EXISTS "public"."project_tags" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "project_id" "uuid" NOT NULL,
+    "tag_id" "uuid" NOT NULL,
+    "applied_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."project_tags" OWNER TO "postgres";
+
+
+-- Primary Key
+
+ALTER TABLE ONLY "public"."project_tags"
+    ADD CONSTRAINT "project_tags_pkey" PRIMARY KEY ("id");
+
+
+-- Foreign Keys
+-- ON DELETE CASCADE: removing a project or a tag removes its pivot rows —
+-- a dangling link is meaningless on either side.
+
+ALTER TABLE ONLY "public"."project_tags"
+    ADD CONSTRAINT "project_tags_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE CASCADE;
+
+ALTER TABLE ONLY "public"."project_tags"
+    ADD CONSTRAINT "project_tags_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE CASCADE;

--- a/supabase/schemas/core/project_tags/02_indexes.sql
+++ b/supabase/schemas/core/project_tags/02_indexes.sql
@@ -1,0 +1,8 @@
+-- Project Tags Indexes
+
+-- A tag can be applied to a project at most once. Also serves as the
+-- project_id lookup index for the global_search tag-filter EXISTS probe.
+CREATE UNIQUE INDEX IF NOT EXISTS "project_tag_uq" ON "public"."project_tags" ("project_id", "tag_id");
+
+-- Supports finding all projects carrying a specific tag.
+CREATE INDEX IF NOT EXISTS "project_tags_tag_id_idx" ON "public"."project_tags" ("tag_id");

--- a/supabase/schemas/core/project_tags/03_rls.sql
+++ b/supabase/schemas/core/project_tags/03_rls.sql
@@ -1,0 +1,25 @@
+-- Project Tags RLS Policies
+
+ALTER TABLE "public"."project_tags" ENABLE ROW LEVEL SECURITY;
+
+-- SELECT Policy
+-- Tag assignments follow project visibility: a project's tags are visible
+-- only to users who can view the project itself (mirrors
+-- projects_select_policy on the projects table).
+
+DROP POLICY IF EXISTS "project_tags_select_policy" ON "public"."project_tags";
+CREATE POLICY "project_tags_select_policy" ON "public"."project_tags"
+  FOR SELECT
+  USING (
+    "user_has_project_permission"(
+      "project_id",
+      'view_project',
+      "auth"."uid"()
+    )
+  );
+
+-- No INSERT/UPDATE/DELETE policies defined.
+-- Write access is intentionally restricted to service_role / migrations only,
+-- matching the tags reference-data pattern. Enforced by RLS (the absence of
+-- write policies), not by grants — auto-expose re-grants the Data API roles
+-- SQL-level access on db reset.

--- a/supabase/schemas/core/project_tags/README.md
+++ b/supabase/schemas/core/project_tags/README.md
@@ -1,0 +1,59 @@
+# Project Tags Module
+
+## Overview
+
+`project_tags` is the many-to-many pivot linking `projects` to `tags`. It was
+introduced in CA-596 so the `global_search` RPC's `filter_by_tag` parameter can
+restrict project results to projects carrying a given tag. It mirrors the
+`session_tags` pivot (which links `tags` to `calculation_sessions`), the only
+pre-existing consumer of the `tags` reference table.
+
+## Table Structure
+
+- `id` - UUID primary key
+- `project_id` - FK to `projects.id`, `ON DELETE CASCADE`
+- `tag_id` - FK to `tags.id`, `ON DELETE CASCADE`
+- `applied_at` - Timestamp when the tag was applied to the project
+
+## Indexes
+
+- `project_tag_uq` - `UNIQUE (project_id, tag_id)`; a tag can be applied to a
+  project at most once. Doubles as the lookup index for the `global_search`
+  tag-filter `EXISTS` probe, which enters by `project_id`.
+- `project_tags_tag_id_idx` - Supports "all projects carrying tag X" lookups.
+
+## RLS
+
+- **SELECT** (`project_tags_select_policy`): follows project visibility via
+  `user_has_project_permission(project_id, 'view_project', auth.uid())` — the
+  same predicate as `projects_select_policy`. A user who cannot view a project
+  cannot see its tag assignments either, including through the auto-exposed
+  Data API.
+- **INSERT/UPDATE/DELETE**: no policies defined. Write access is intentionally
+  restricted to `service_role` / migrations only, matching the `tags`
+  reference-data pattern (`tags` rows themselves are also read-only through
+  the Data API). The enforcement point is RLS, not grants: auto-expose
+  (CA-729) grants the Data API roles full SQL-level access on `db reset`, so
+  it is the absence of write policies that denies client writes — pinned by a
+  `throws_ok` INSERT test in `global_search_tag_filter_test.sql`.
+
+**Asymmetry with `session_tags`:** `session_tags` predates this repo's RLS
+policy conventions and has RLS enabled with no policies at all (fully closed
+via the Data API). `project_tags` deliberately opens SELECT under project
+visibility because `global_search` runs as `SECURITY INVOKER` and must be able
+to evaluate the tag predicate as the calling user. The FK behavior also
+differs: `session_tags` has no `ON DELETE CASCADE` on either FK (the CA-A-6
+design doc specified cascade, but migration 21 didn't implement it), while
+`project_tags` implements both cascades — don't assume parity between the two
+pivots.
+
+## Consumers
+
+- `global_search` RPC (`supabase/schemas/global_search/global_search/03_functions.sql`):
+  applies `filter_by_tag` to the projects result via an `EXISTS` probe against
+  this table joined to `tags` by name.
+
+## Related Tables
+
+- `tags` — reference list of tag names (public SELECT).
+- `projects` — the tagged entity; project deletion cascades here.

--- a/supabase/schemas/global_search/global_search/README.md
+++ b/supabase/schemas/global_search/global_search/README.md
@@ -15,7 +15,7 @@ Returns `jsonb`: `{ projects: [...], estimations: [...], members: [...] }`.
 | Param | Type | Default | Notes |
 |---|---|---|---|
 | `query` | `text` | required | Matched case-insensitively against name/description fields. |
-| `filter_by_tag` | `text` | `NULL` | Reserved; not yet applied to any query. See [CA-596](https://ripplearc.youtrack.cloud/issue/CA-596). |
+| `filter_by_tag` | `text` | `NULL` | Restricts the **projects** result to projects linked to a tag with this exact name via `project_tags` (see `core/project_tags`). `NULL` means no tag filter; a name matching no tag returns zero projects. Estimations and members are unaffected. Wired in [CA-596](https://ripplearc.youtrack.cloud/issue/CA-596). |
 | `filter_by_date_from` | `timestamptz` | `NULL` | Inclusive lower bound on `updated_at`. |
 | `filter_by_date_to` | `timestamptz` | `NULL` | Inclusive upper bound on `updated_at`. |
 | `filter_by_owners` | `uuid[]` | `NULL` | Restricts projects/estimates to rows whose `creator_user_id` is in the array. `NULL` **and an empty array** both mean "no owner filter" — an empty array is the natural "no owners selected" client state and must not silently match zero rows. Replaced the single-`uuid` `filter_by_owner` in [CA-737](https://ripplearc.youtrack.cloud/issue/CA-737). |

--- a/supabase/tests/functions/global_search_tag_filter_test.sql
+++ b/supabase/tests/functions/global_search_tag_filter_test.sql
@@ -1,0 +1,194 @@
+BEGIN;
+
+-- Tests for CA-596: global_search's filter_by_tag param, now applied to the
+-- projects result via the project_tags pivot. Covers the NULL "no filter"
+-- contract, exact-name matching, the RLS boundary on project_tags (tag
+-- assignments follow project visibility), the estimations path being
+-- unaffected, the interaction with the CA-752 date-range filter, and the
+-- pivot's ON DELETE CASCADE behavior on both FK sides.
+
+SELECT plan(13);
+
+SELECT has_table('public', 'project_tags', 'project_tags pivot table exists');
+
+SELECT has_index(
+  'public',
+  'project_tags',
+  'project_tag_uq',
+  ARRAY['project_id', 'tag_id'],
+  'project_tags has the unique (project_id, tag_id) index'
+);
+
+DO $$
+DECLARE
+  v_viewer_id uuid := '11111111-1111-1111-1111-111111111111';
+  v_viewer_credential_id uuid := '22222222-2222-2222-2222-222222222222';
+  v_prof_role_id uuid := '55555555-5555-5555-5555-555555555555';
+  v_admin_role_id uuid := '66666666-6666-6666-6666-666666666666';
+  v_project_a uuid := '33333333-3333-3333-3333-333333333333';
+  v_project_b uuid := '44444444-4444-4444-4444-444444444444';
+  v_project_c uuid := '99999999-9999-9999-9999-999999999999';
+  v_project_d uuid := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+  v_tag_concrete uuid := 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  v_tag_steel uuid := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+  v_tag_shared uuid := 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  v_tag_unused uuid := 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+  v_estimate_a uuid := '77777777-7777-7777-7777-777777777777';
+BEGIN
+  INSERT INTO professional_roles (id, name) VALUES (v_prof_role_id, 'Test Role');
+
+  INSERT INTO users (id, credential_id, email, first_name, last_name, professional_role, created_at, user_status, user_preferences, country_code)
+    VALUES (v_viewer_id, v_viewer_credential_id, 'tag_filter_viewer@example.com', 'Tag', 'Viewer', v_prof_role_id, now(), 'active', '{}', '+1');
+
+  INSERT INTO roles (id, role_name, level, context_type) VALUES (v_admin_role_id, 'TestAdmin', 4, 'project');
+  INSERT INTO role_permissions (role_id, permission_id)
+    SELECT v_admin_role_id, id FROM permissions WHERE permission_key IN ('view_project', 'edit_project');
+
+  -- Project B is backdated 60 days so the date-range interaction test can
+  -- exclude it while the tag filter alone includes it. Project D is the RLS
+  -- probe: the viewer is NOT a member, so neither the project nor its tag
+  -- assignment may surface anywhere.
+  INSERT INTO projects (id, project_name, creator_user_id, created_at, updated_at, project_status)
+    VALUES
+      (v_project_a, 'tag filter project alpha', v_viewer_id, now() - interval '60 days', now() - interval '5 days', 'active'),
+      (v_project_b, 'tag filter project beta', v_viewer_id, now() - interval '60 days', now() - interval '60 days', 'active'),
+      (v_project_c, 'tag filter project gamma', v_viewer_id, now() - interval '60 days', now() - interval '5 days', 'active'),
+      (v_project_d, 'tag filter project delta', v_viewer_id, now() - interval '60 days', now() - interval '5 days', 'active');
+
+  INSERT INTO project_members (project_id, user_id, role_id, membership_status, joined_at)
+    VALUES
+      (v_project_a, v_viewer_id, v_admin_role_id, 'joined', now()),
+      (v_project_b, v_viewer_id, v_admin_role_id, 'joined', now()),
+      (v_project_c, v_viewer_id, v_admin_role_id, 'joined', now());
+
+  INSERT INTO tags (id, name)
+    VALUES
+      (v_tag_concrete, 'tagfilter-concrete'),
+      (v_tag_steel, 'tagfilter-steel'),
+      (v_tag_shared, 'tagfilter-shared'),
+      (v_tag_unused, 'tagfilter-unused');
+
+  -- A: concrete + shared. B: steel + shared. C: untagged. D: concrete but
+  -- invisible to the viewer.
+  INSERT INTO project_tags (project_id, tag_id)
+    VALUES
+      (v_project_a, v_tag_concrete),
+      (v_project_a, v_tag_shared),
+      (v_project_b, v_tag_steel),
+      (v_project_b, v_tag_shared),
+      (v_project_d, v_tag_concrete);
+
+  -- One estimate on project A so the estimations path is exercised by the
+  -- "estimations unaffected by filter_by_tag" assertion.
+  INSERT INTO cost_estimates (id, project_id, estimate_name, creator_user_id, markup_type, total_cost, created_at, updated_at)
+    VALUES (v_estimate_a, v_project_a, 'tag filter estimate alpha', v_viewer_id, 'overall', 1000.00, now() - interval '5 days', now() - interval '5 days');
+END $$;
+
+SET LOCAL ROLE authenticated;
+-- cost_estimates RLS reads get_cost_estimations from JWT app_metadata claims
+-- directly (jwt_has_project_permission), not from role_permissions/
+-- project_members — project A must be listed here for the cost_estimates
+-- fixture to be visible to this test's queries.
+SELECT set_config('request.jwt.claims', '{
+  "sub": "22222222-2222-2222-2222-222222222222",
+  "app_metadata": {
+    "projects": {
+      "33333333-3333-3333-3333-333333333333": ["get_cost_estimations"]
+    }
+  }
+}', true);
+
+-- Test 3: NULL filter_by_tag returns all matching visible projects (no filter)
+SELECT is(
+  jsonb_array_length(global_search('tag filter', NULL, NULL, NULL, NULL, 'dashboard') -> 'projects'),
+  3,
+  'NULL filter_by_tag returns all matching projects'
+);
+
+-- Test 4: a tag narrows projects to those carrying it
+SELECT is(
+  jsonb_array_length(global_search('tag filter', 'tagfilter-concrete', NULL, NULL, NULL, 'dashboard') -> 'projects'),
+  1,
+  'filter_by_tag returns only projects carrying that tag'
+);
+
+-- Test 5: and it is the right project (not the RLS-hidden delta, which
+-- carries the same tag)
+SELECT is(
+  global_search('tag filter', 'tagfilter-concrete', NULL, NULL, NULL, 'dashboard') -> 'projects' -> 0 ->> 'id',
+  '33333333-3333-3333-3333-333333333333',
+  'The concrete-tagged result is project alpha, not the RLS-hidden delta'
+);
+
+-- Test 6: a tag applied to no visible project returns zero projects
+SELECT is(
+  jsonb_array_length(global_search('tag filter', 'tagfilter-unused', NULL, NULL, NULL, 'dashboard') -> 'projects'),
+  0,
+  'A tag with no projects returns zero projects'
+);
+
+-- Test 7: a tag on two projects returns both
+SELECT is(
+  jsonb_array_length(global_search('tag filter', 'tagfilter-shared', NULL, NULL, NULL, 'dashboard') -> 'projects'),
+  2,
+  'A tag applied to two projects returns both'
+);
+
+-- Test 8: tag filter intersects with the date-range filter — beta carries
+-- the shared tag but is backdated 60 days, so a from-bound of 10 days ago
+-- leaves only alpha
+SELECT is(
+  jsonb_array_length(global_search('tag filter', 'tagfilter-shared', now() - interval '10 days', NULL, NULL, 'dashboard') -> 'projects'),
+  1,
+  'Tag filter combined with filter_by_date_from intersects on projects'
+);
+
+-- Test 9: filter_by_tag applies only to projects — the estimations result is
+-- unaffected even when the filtered tag excludes the estimate's project
+SELECT is(
+  jsonb_array_length(global_search('tag filter', 'tagfilter-steel', NULL, NULL, NULL, 'estimation') -> 'estimations'),
+  1,
+  'filter_by_tag does not filter the estimations result'
+);
+
+-- Test 10: project_tags RLS — of the 5 pivot rows, the viewer sees only the
+-- 4 on projects they can view; delta's assignment is hidden
+SELECT is(
+  (SELECT count(*)::int FROM project_tags),
+  4,
+  'project_tags SELECT is limited to rows on viewable projects'
+);
+
+-- Test 11: no write policies exist — an authenticated client INSERT is
+-- denied by RLS. This is the entire write-path enforcement: auto-expose
+-- grants INSERT to the Data API roles on db reset, so the absence of a
+-- write policy is what keeps project_tags service_role-only.
+SELECT throws_ok(
+  $$INSERT INTO project_tags (project_id, tag_id)
+      VALUES ('33333333-3333-3333-3333-333333333333', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')$$,
+  '42501',
+  'new row violates row-level security policy for table "project_tags"',
+  'Authenticated clients cannot INSERT into project_tags (no write policy)'
+);
+
+RESET ROLE;
+
+-- Test 12: deleting a project cascades to its pivot rows
+DELETE FROM projects WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+SELECT is(
+  (SELECT count(*)::int FROM project_tags WHERE project_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd'),
+  0,
+  'Deleting a project cascades to project_tags'
+);
+
+-- Test 13: deleting a tag cascades to its pivot rows
+DELETE FROM tags WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+SELECT is(
+  (SELECT count(*)::int FROM project_tags WHERE tag_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+  0,
+  'Deleting a tag cascades to project_tags'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

Backend half of [CA-596](https://ripplearc.youtrack.cloud/issue/CA-596): the Flutter tag filter sheets already send `filter_by_tag` on every search, but `global_search` accepted the parameter without applying it — no project-to-tag association existed in the schema, so users selecting a tag got unfiltered results.

- **New `project_tags` pivot** (`schemas/core/project_tags/`): many-to-many `projects` ↔ `tags`, modeled on the existing `session_tags` pivot (`id`, `project_id` FK, `tag_id` FK, `applied_at`, `UNIQUE (project_id, tag_id)`, index on `tag_id`). Both FKs are `ON DELETE CASCADE` — a dangling link is meaningless on either side.
- **RLS**: SELECT follows project visibility via `user_has_project_permission(project_id, 'view_project', auth.uid())` — the same predicate as `projects_select_policy`, so a tag assignment is never visible (RPC or Data API) to someone who can't view the project. No write policies: writes are `service_role`/migrations only, matching the `tags` reference-data pattern.
- **Migration 39** (generated via `supabase db diff --from=migrations --to=local` from the declarative schema files, per the module README workflow): creates the table/indexes/policy and recreates `public.global_search` with the tag predicate applied to the projects block: `filter_by_tag IS NULL OR EXISTS (… project_tags JOIN tags ON tags.id = tag_id WHERE project_id = projects.id AND tags.name = filter_by_tag)`.
- **Contract**: `NULL` means "no tag filter" (behavior unchanged); the match is exact against `tags.name`; a name matching no tag returns zero projects. The filter applies **only to the projects result** — estimations and members are unaffected. The RPC signature is unchanged.
- **Schema backfill**: `global_search/global_search/03_functions.sql` mirrors the migration body exactly; both CA-596 TODO markers and the "reserved; not yet applied" notes are removed; module READMEs updated (`core/project_tags/` added, `global_search` parameter table updated).

## Test plan

- New `global_search_tag_filter_test.sql` (13 pgTAP assertions): NULL "no filter" contract, exact-name narrowing, a tag on two projects returning both, an unused tag returning zero, tag×date-range intersection, the estimations path being unaffected by `filter_by_tag`, the RLS boundary (a tagged project the viewer isn't a member of is excluded from search results *and* its pivot row is invisible to direct SELECT), both `ON DELETE CASCADE` sides, a `throws_ok` INSERT-as-authenticated write-denial pin, plus structural pins (`has_table`, unique-index shape). Runs under `SET LOCAL ROLE authenticated` with JWT `app_metadata.projects` claims for cost_estimates RLS.
- Verified locally with the CI-pinned Supabase CLI 2.106.0: `supabase db reset` applies migration 39 cleanly on a fresh DB; `supabase test db` passes all suites (185/185 across all 17 suites on this branch; 191 including the stacked #47).
