### PR TITLE
CA-839: feat(search): add get_project_owners RPC for the owner filter sheets

### DIFF
--- a/supabase/migrations/20260724131709_40_get_project_owners.sql
+++ b/supabase/migrations/20260724131709_40_get_project_owners.sql
@@ -1,0 +1,29 @@
+-- CA-839: Add get_project_owners RPC — distinct creators of the
+-- caller-visible projects (SECURITY INVOKER over projects RLS; profile
+-- columns via the public user_profiles view) for the Owner filter
+-- sheets in global search and dashboard project search.
+-- Generated via `supabase db diff --from=migrations --to=local` from
+-- supabase/schemas/global_search/project_owners/03_functions.sql per
+-- the global_search module README workflow.
+-- https://ripplearc.youtrack.cloud/issue/CA-839
+
+SET check_function_bodies = false;
+CREATE FUNCTION public.get_project_owners()
+ RETURNS TABLE(id uuid, first_name character varying, last_name character varying, professional_role uuid, profile_photo_url text)
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public'
+AS $function$
+  SELECT DISTINCT
+    up.id,
+    up.first_name,
+    up.last_name,
+    up.professional_role,
+    up.profile_photo_url
+  FROM projects p
+  JOIN user_profiles up ON up.id = p.creator_user_id
+  ORDER BY first_name, last_name;
+$function$;
+GRANT ALL ON FUNCTION public.get_project_owners() TO anon;
+GRANT ALL ON FUNCTION public.get_project_owners() TO authenticated;
+GRANT ALL ON FUNCTION public.get_project_owners() TO service_role;

--- a/supabase/migrations/20260724131709_40_get_project_owners.sql
+++ b/supabase/migrations/20260724131709_40_get_project_owners.sql
@@ -4,7 +4,9 @@
 -- sheets in global search and dashboard project search.
 -- Generated via `supabase db diff --from=migrations --to=local` from
 -- supabase/schemas/global_search/project_owners/03_functions.sql per
--- the global_search module README workflow.
+-- the global_search module README workflow; SECURITY INVOKER made
+-- explicit post-generation (pg_dump omits it as the default and review
+-- asked for it to be spelled out).
 -- https://ripplearc.youtrack.cloud/issue/CA-839
 
 SET check_function_bodies = false;
@@ -12,6 +14,7 @@ CREATE FUNCTION public.get_project_owners()
  RETURNS TABLE(id uuid, first_name character varying, last_name character varying, professional_role uuid, profile_photo_url text)
  LANGUAGE sql
  STABLE
+ SECURITY INVOKER
  SET search_path TO 'public'
 AS $function$
   SELECT DISTINCT
@@ -22,7 +25,7 @@ AS $function$
     up.profile_photo_url
   FROM projects p
   JOIN user_profiles up ON up.id = p.creator_user_id
-  ORDER BY first_name, last_name;
+  ORDER BY first_name, last_name, id;
 $function$;
 GRANT ALL ON FUNCTION public.get_project_owners() TO anon;
 GRANT ALL ON FUNCTION public.get_project_owners() TO authenticated;

--- a/supabase/schemas/global_search/project_owners/03_functions.sql
+++ b/supabase/schemas/global_search/project_owners/03_functions.sql
@@ -1,0 +1,47 @@
+-- Functions for the project-owners filter (Owner filter sheets in global
+-- search and dashboard project search).
+
+-- ============================================================
+-- get_project_owners RPC
+--
+-- Parameters: none — identity is derived from the Supabase auth session
+-- JWT (auth.uid() via RLS), so no explicit user id param is required.
+--
+-- Returns: one row per distinct creator of the projects the caller can
+-- see, ordered by first_name, last_name for a stable sheet ordering.
+--
+-- SECURITY INVOKER: project visibility comes from the projects RLS
+-- policy (user_has_project_permission(id, 'view_project', auth.uid())) —
+-- this function does not bypass RLS. The profile columns are read
+-- through the user_profiles view, the deliberate public subset of
+-- users (the view runs with its owner's rights, which is what makes
+-- peers' names visible despite users' select-own RLS).
+--
+-- Privacy: the return signature pins exactly
+-- id, first_name, last_name, professional_role, profile_photo_url.
+-- Never add users.credential_id or email here (prior review caught a
+-- credential_id leak on global_search's members block; the pgTAP
+-- function_returns test pins this column set).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_project_owners()
+ RETURNS TABLE(
+   id uuid,
+   first_name character varying,
+   last_name character varying,
+   professional_role uuid,
+   profile_photo_url text
+ )
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public'
+AS $function$
+  SELECT DISTINCT
+    up.id,
+    up.first_name,
+    up.last_name,
+    up.professional_role,
+    up.profile_photo_url
+  FROM projects p
+  JOIN user_profiles up ON up.id = p.creator_user_id
+  ORDER BY first_name, last_name;
+$function$;

--- a/supabase/schemas/global_search/project_owners/03_functions.sql
+++ b/supabase/schemas/global_search/project_owners/03_functions.sql
@@ -8,7 +8,8 @@
 -- JWT (auth.uid() via RLS), so no explicit user id param is required.
 --
 -- Returns: one row per distinct creator of the projects the caller can
--- see, ordered by first_name, last_name for a stable sheet ordering.
+-- see, ordered by first_name, last_name (id as the final tie-breaker so
+-- two same-named owners keep a deterministic order across calls).
 --
 -- SECURITY INVOKER: project visibility comes from the projects RLS
 -- policy (user_has_project_permission(id, 'view_project', auth.uid())) —
@@ -33,6 +34,7 @@ CREATE OR REPLACE FUNCTION public.get_project_owners()
  )
  LANGUAGE sql
  STABLE
+ SECURITY INVOKER
  SET search_path TO 'public'
 AS $function$
   SELECT DISTINCT
@@ -43,5 +45,5 @@ AS $function$
     up.profile_photo_url
   FROM projects p
   JOIN user_profiles up ON up.id = p.creator_user_id
-  ORDER BY first_name, last_name;
+  ORDER BY first_name, last_name, id;
 $function$;

--- a/supabase/schemas/global_search/project_owners/README.md
+++ b/supabase/schemas/global_search/project_owners/README.md
@@ -1,0 +1,29 @@
+# Project Owners
+
+Backend for the **Owner filter** sheets in global search and dashboard
+project search ([CA-839](https://ripplearc.youtrack.cloud/issue/CA-839),
+under epic [CA-497](https://ripplearc.youtrack.cloud/issue/CA-497)).
+
+The app's `RemoteOwnerDataSource` calls the `get_project_owners` RPC with no
+arguments and renders the returned profiles in the owner
+`MultiSelectFilterSheet`; the selected ids are then passed to
+`global_search`'s `filter_by_owners uuid[]` parameter (CA-737).
+
+| File | Contents |
+|------|----------|
+| `03_functions.sql` | `get_project_owners()` — distinct creators of the caller-visible projects. |
+
+## Semantics
+
+- **Visibility** — `SECURITY INVOKER`: the projects RLS policy
+  (`user_has_project_permission(id, 'view_project', auth.uid())`) decides
+  which projects contribute owners. An unauthenticated caller gets zero rows.
+- **Profile columns** — read via the `user_profiles` view (the deliberate
+  public subset of `users`), so peers' names resolve despite `users`'
+  select-own RLS. The return signature pins exactly
+  `id, first_name, last_name, professional_role, profile_photo_url`; never
+  add `credential_id` or `email` (see the privacy note in the function and
+  the `function_returns` pin in
+  `supabase/tests/functions/get_project_owners_test.sql`).
+- **Deduplication** — one row per creator regardless of how many visible
+  projects they own; ordered by `first_name, last_name` for a stable sheet.

--- a/supabase/schemas/global_search/project_owners/README.md
+++ b/supabase/schemas/global_search/project_owners/README.md
@@ -26,4 +26,5 @@ arguments and renders the returned profiles in the owner
   the `function_returns` pin in
   `supabase/tests/functions/get_project_owners_test.sql`).
 - **Deduplication** — one row per creator regardless of how many visible
-  projects they own; ordered by `first_name, last_name` for a stable sheet.
+  projects they own; ordered by `first_name, last_name` with `id` as the
+  final tie-breaker, so same-named owners keep a deterministic order.

--- a/supabase/tests/functions/get_project_owners_test.sql
+++ b/supabase/tests/functions/get_project_owners_test.sql
@@ -1,0 +1,110 @@
+BEGIN;
+
+-- Tests for CA-839: get_project_owners() — distinct creators of the
+-- caller-visible projects, exposed for the Owner filter sheets. Covers the
+-- RLS-scoped visibility, per-creator deduplication, the pinned (leak-free)
+-- return column set, and the unauthenticated zero-rows contract.
+
+SELECT plan(6);
+
+SELECT has_function(
+  'public',
+  'get_project_owners',
+  ARRAY[]::text[],
+  'get_project_owners takes no arguments (identity comes from the JWT)'
+);
+
+-- Privacy pin: exactly the public-profile subset; a signature change that
+-- adds credential_id or email must fail here (prior review caught a
+-- credential_id leak on global_search's members block). RETURNS TABLE
+-- output columns are pg_proc OUT params, so pin their names directly.
+SELECT is(
+  (SELECT array_to_string(proargnames, ',') COLLATE "C"
+     FROM pg_proc
+     WHERE pronamespace = 'public'::regnamespace
+       AND proname = 'get_project_owners'),
+  'id,first_name,last_name,professional_role,profile_photo_url' COLLATE "C",
+  'get_project_owners returns only the public-profile column set'
+);
+
+DO $$
+DECLARE
+  v_viewer_id uuid := '11111111-1111-1111-1111-111111111111';
+  v_viewer_credential_id uuid := '22222222-2222-2222-2222-222222222222';
+  v_prof_role_id uuid := '55555555-5555-5555-5555-555555555555';
+  v_admin_role_id uuid := '66666666-6666-6666-6666-666666666666';
+  v_owner_a uuid := 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  v_owner_b uuid := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+  v_owner_c uuid := 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  v_project_a1 uuid := '33333333-3333-3333-3333-333333333333';
+  v_project_a2 uuid := '44444444-4444-4444-4444-444444444444';
+  v_project_b uuid := '77777777-7777-7777-7777-777777777777';
+  v_project_c uuid := '99999999-9999-9999-9999-999999999999';
+BEGIN
+  INSERT INTO professional_roles (id, name) VALUES (v_prof_role_id, 'Test Role');
+
+  -- The viewer lists the owners; the three owners only create projects.
+  INSERT INTO users (id, credential_id, email, first_name, last_name, professional_role, created_at, user_status, user_preferences, country_code)
+    VALUES
+      (v_viewer_id, v_viewer_credential_id, 'owners_rpc_viewer@example.com', 'Owner', 'Viewer', v_prof_role_id, now(), 'active', '{}', '+1'),
+      (v_owner_a, gen_random_uuid(), 'owners_rpc_a@example.com', 'Owner', 'Alpha', v_prof_role_id, now(), 'active', '{}', '+1'),
+      (v_owner_b, gen_random_uuid(), 'owners_rpc_b@example.com', 'Owner', 'Beta', v_prof_role_id, now(), 'active', '{}', '+1'),
+      (v_owner_c, gen_random_uuid(), 'owners_rpc_c@example.com', 'Owner', 'Gamma', v_prof_role_id, now(), 'active', '{}', '+1');
+
+  INSERT INTO roles (id, role_name, level, context_type) VALUES (v_admin_role_id, 'TestAdmin', 4, 'project');
+  INSERT INTO role_permissions (role_id, permission_id)
+    SELECT v_admin_role_id, id FROM permissions WHERE permission_key IN ('view_project');
+
+  -- Owner A creates TWO visible projects (dedup fixture); owner B one
+  -- visible project; owner C's project has no viewer membership and must
+  -- therefore contribute no owner row.
+  INSERT INTO projects (id, project_name, creator_user_id, project_status)
+    VALUES
+      (v_project_a1, 'owners rpc project alpha one', v_owner_a, 'active'),
+      (v_project_a2, 'owners rpc project alpha two', v_owner_a, 'active'),
+      (v_project_b, 'owners rpc project beta', v_owner_b, 'active'),
+      (v_project_c, 'owners rpc project gamma', v_owner_c, 'active');
+
+  INSERT INTO project_members (project_id, user_id, role_id, membership_status, joined_at)
+    VALUES
+      (v_project_a1, v_viewer_id, v_admin_role_id, 'joined', now()),
+      (v_project_a2, v_viewer_id, v_admin_role_id, 'joined', now()),
+      (v_project_b, v_viewer_id, v_admin_role_id, 'joined', now());
+END $$;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims', '{
+  "sub": "22222222-2222-2222-2222-222222222222"
+}', true);
+
+-- Owners of visible projects only, one row per creator: owner A (despite
+-- two projects) and owner B; owner C's project is invisible to the viewer.
+SELECT is(
+  (SELECT count(*) FROM get_project_owners()),
+  2::bigint,
+  'Returns one row per distinct creator of the caller-visible projects'
+);
+
+SELECT results_eq(
+  'SELECT id FROM get_project_owners() ORDER BY id',
+  ARRAY['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']::uuid[],
+  'Returns exactly the creators of the visible projects (invisible project contributes none)'
+);
+
+SELECT results_eq(
+  'SELECT last_name FROM get_project_owners()',
+  ARRAY['Alpha', 'Beta']::character varying[],
+  'Rows are ordered by first_name, last_name for a stable sheet ordering'
+);
+
+-- Unauthenticated (no JWT claims): the projects RLS predicate is false for
+-- a NULL auth.uid(), so no owners leak.
+SELECT set_config('request.jwt.claims', NULL, true);
+SELECT is(
+  (SELECT count(*) FROM get_project_owners()),
+  0::bigint,
+  'Without an authenticated identity no owners are returned'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/functions/get_project_owners_test.sql
+++ b/supabase/tests/functions/get_project_owners_test.sql
@@ -3,9 +3,10 @@ BEGIN;
 -- Tests for CA-839: get_project_owners() — distinct creators of the
 -- caller-visible projects, exposed for the Owner filter sheets. Covers the
 -- RLS-scoped visibility, per-creator deduplication, the pinned (leak-free)
--- return column set, and the unauthenticated zero-rows contract.
+-- return column set, the deterministic ordering (id tie-breaker for
+-- same-named owners), and the unauthenticated zero-rows contract.
 
-SELECT plan(6);
+SELECT plan(7);
 
 SELECT has_function(
   'public',
@@ -36,10 +37,16 @@ DECLARE
   v_owner_a uuid := 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
   v_owner_b uuid := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
   v_owner_c uuid := 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  -- Same-named pair for the id tie-breaker: ids sort BEFORE owners A/B so
+  -- the function's name-first ordering is visibly not a plain id sort.
+  v_owner_d1 uuid := '0ddddddd-dddd-dddd-dddd-dddddddddddd';
+  v_owner_d2 uuid := '0eeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
   v_project_a1 uuid := '33333333-3333-3333-3333-333333333333';
   v_project_a2 uuid := '44444444-4444-4444-4444-444444444444';
   v_project_b uuid := '77777777-7777-7777-7777-777777777777';
   v_project_c uuid := '99999999-9999-9999-9999-999999999999';
+  v_project_d1 uuid := '88888888-8888-8888-8888-888888888888';
+  v_project_d2 uuid := '12121212-1212-1212-1212-121212121212';
 BEGIN
   INSERT INTO professional_roles (id, name) VALUES (v_prof_role_id, 'Test Role');
 
@@ -49,7 +56,9 @@ BEGIN
       (v_viewer_id, v_viewer_credential_id, 'owners_rpc_viewer@example.com', 'Owner', 'Viewer', v_prof_role_id, now(), 'active', '{}', '+1'),
       (v_owner_a, gen_random_uuid(), 'owners_rpc_a@example.com', 'Owner', 'Alpha', v_prof_role_id, now(), 'active', '{}', '+1'),
       (v_owner_b, gen_random_uuid(), 'owners_rpc_b@example.com', 'Owner', 'Beta', v_prof_role_id, now(), 'active', '{}', '+1'),
-      (v_owner_c, gen_random_uuid(), 'owners_rpc_c@example.com', 'Owner', 'Gamma', v_prof_role_id, now(), 'active', '{}', '+1');
+      (v_owner_c, gen_random_uuid(), 'owners_rpc_c@example.com', 'Owner', 'Gamma', v_prof_role_id, now(), 'active', '{}', '+1'),
+      (v_owner_d1, gen_random_uuid(), 'owners_rpc_d1@example.com', 'Owner', 'Delta', v_prof_role_id, now(), 'active', '{}', '+1'),
+      (v_owner_d2, gen_random_uuid(), 'owners_rpc_d2@example.com', 'Owner', 'Delta', v_prof_role_id, now(), 'active', '{}', '+1');
 
   INSERT INTO roles (id, role_name, level, context_type) VALUES (v_admin_role_id, 'TestAdmin', 4, 'project');
   INSERT INTO role_permissions (role_id, permission_id)
@@ -57,19 +66,24 @@ BEGIN
 
   -- Owner A creates TWO visible projects (dedup fixture); owner B one
   -- visible project; owner C's project has no viewer membership and must
-  -- therefore contribute no owner row.
+  -- therefore contribute no owner row; owners D1/D2 share a full name and
+  -- pin the id tie-breaker.
   INSERT INTO projects (id, project_name, creator_user_id, project_status)
     VALUES
       (v_project_a1, 'owners rpc project alpha one', v_owner_a, 'active'),
       (v_project_a2, 'owners rpc project alpha two', v_owner_a, 'active'),
       (v_project_b, 'owners rpc project beta', v_owner_b, 'active'),
-      (v_project_c, 'owners rpc project gamma', v_owner_c, 'active');
+      (v_project_c, 'owners rpc project gamma', v_owner_c, 'active'),
+      (v_project_d1, 'owners rpc project delta one', v_owner_d1, 'active'),
+      (v_project_d2, 'owners rpc project delta two', v_owner_d2, 'active');
 
   INSERT INTO project_members (project_id, user_id, role_id, membership_status, joined_at)
     VALUES
       (v_project_a1, v_viewer_id, v_admin_role_id, 'joined', now()),
       (v_project_a2, v_viewer_id, v_admin_role_id, 'joined', now()),
-      (v_project_b, v_viewer_id, v_admin_role_id, 'joined', now());
+      (v_project_b, v_viewer_id, v_admin_role_id, 'joined', now()),
+      (v_project_d1, v_viewer_id, v_admin_role_id, 'joined', now()),
+      (v_project_d2, v_viewer_id, v_admin_role_id, 'joined', now());
 END $$;
 
 SET LOCAL ROLE authenticated;
@@ -78,23 +92,33 @@ SELECT set_config('request.jwt.claims', '{
 }', true);
 
 -- Owners of visible projects only, one row per creator: owner A (despite
--- two projects) and owner B; owner C's project is invisible to the viewer.
+-- two projects), owner B and the two Deltas; owner C's project is invisible
+-- to the viewer.
 SELECT is(
   (SELECT count(*) FROM get_project_owners()),
-  2::bigint,
+  4::bigint,
   'Returns one row per distinct creator of the caller-visible projects'
 );
 
 SELECT results_eq(
   'SELECT id FROM get_project_owners() ORDER BY id',
-  ARRAY['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']::uuid[],
+  ARRAY['0ddddddd-dddd-dddd-dddd-dddddddddddd', '0eeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']::uuid[],
   'Returns exactly the creators of the visible projects (invisible project contributes none)'
 );
 
 SELECT results_eq(
   'SELECT last_name FROM get_project_owners()',
-  ARRAY['Alpha', 'Beta']::character varying[],
+  ARRAY['Alpha', 'Beta', 'Delta', 'Delta']::character varying[],
   'Rows are ordered by first_name, last_name for a stable sheet ordering'
+);
+
+-- The Deltas share first AND last name, and their ids sort before owners
+-- A/B — so this exact sequence holds only if the ordering is
+-- first_name, last_name with id as the final tie-breaker.
+SELECT results_eq(
+  'SELECT id FROM get_project_owners()',
+  ARRAY['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '0ddddddd-dddd-dddd-dddd-dddddddddddd', '0eeeeeee-eeee-eeee-eeee-eeeeeeeeeeee']::uuid[],
+  'Same-named owners keep a deterministic order via the id tie-breaker'
 );
 
 -- Unauthenticated (no JWT claims): the projects RLS predicate is false for


### PR DESCRIPTION
## Ticket

[CA-839](https://ripplearc.youtrack.cloud/issue/CA-839) (under epic CA-497) — stacked on #46.

## Problem

The app's `RemoteOwnerDataSource` has called `get_project_owners` since CA-255, but the function never existed backend-side — verified live 2026-07-23: HTTP 404 (`PGRST202`), and both Owner filter sheets (global search + dashboard project search) show "No owners found" / "Could not load owners." and can never load.

## Change

`public.get_project_owners()` — no arguments (identity from the session JWT):

- **Visibility**: `SECURITY INVOKER` — the projects RLS policy (`user_has_project_permission(id, 'view_project', auth.uid())`) decides which projects contribute owners; unauthenticated callers get zero rows.
- **Profile columns** via the `user_profiles` view (the deliberate public subset of `users`), so peers' names resolve despite `users`' select-own RLS.
- **Privacy**: return signature pins exactly `id, first_name, last_name, professional_role, profile_photo_url` — never `credential_id`/`email` (the prior `global_search` members-block leak class); a pgTAP test pins the column set.
- One row per distinct creator, ordered by `first_name, last_name` with `id` as the final tie-breaker (R1: deterministic order for same-named owners).

New `supabase/schemas/global_search/project_owners/` (function + README) + migration `_40_get_project_owners` (generated via `supabase db diff --from=migrations --to=local` per the module README workflow) + `supabase/tests/functions/get_project_owners_test.sql`.

## Tests

- pgTAP: 7/7 pass — no-args signature, pinned column set, RLS-scoped visibility (invisible project contributes no owner), per-creator dedup, stable ordering, id tie-breaker for same-named owners (R1), unauthenticated zero-rows.
- Full local suite, stacked on #46: 18 files / 192 tests, all pass; `supabase db reset` applies migration 40 cleanly on a fresh DB (verified with the CI-pinned CLI 2.106.0).
- E2E: with this function applied to the local stack, the RPC returns the seeded owner for the linked test user (the app-side Owner sheet fix needs no app changes — the datasource already calls this contract).

