### PR TITLE
CA-963: feat(consent): add consent_versions and the current_consent_versions view

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ npx supabase test db
 | `cost_estimate_activity_logging_test` | End-to-end activity logging via triggers |
 | `cascade_delete_test` | Soft-delete cascade behavior |
 | `check_email_exists_test` | Email lookup RPC function |
+| `consent_versions_test` | Consent version constraints, the `current_consent_versions` view's in-force rules, and read-only RLS |
 
 > Tests are **required to pass** on every PR — CI will block merge on failure.
 

--- a/supabase/migrations/20260814125200_41_consent_versions.sql
+++ b/supabase/migrations/20260814125200_41_consent_versions.sql
@@ -1,0 +1,60 @@
+-- CA-963: Add consent_versions — the published version of each consent
+-- document, and the current_consent_versions view that resolves which one is
+-- in force (highest version whose effective_from has passed). Backs the
+-- server-driven versioned consent gate in construculator-app.
+--
+-- Read-only for clients: SELECT for authenticated, no write policy for any
+-- role, so publishing stays a migration-only act.
+--
+-- Written by hand rather than via `supabase db diff`: config.toml declares
+-- schema_paths = [], so the CLI has no declared schema to diff against. Mirrors
+-- supabase/schemas/consent/consent_versions/ exactly — keep the two in step.
+--
+-- The user_consents log, consent_action_enum and the jwt_internal_user_id()
+-- RLS helper land in a follow-up migration on this ticket.
+-- https://ripplearc.youtrack.cloud/issue/CA-963
+
+CREATE TYPE public.consent_type_enum AS ENUM (
+  'terms_and_privacy',
+  'analytics'
+);
+
+ALTER TYPE public.consent_type_enum OWNER TO postgres;
+
+CREATE TABLE IF NOT EXISTS public.consent_versions (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  consent_type   public.consent_type_enum NOT NULL,
+  version        integer NOT NULL,
+  document_url   text NOT NULL,
+  effective_from timestamptz NOT NULL DEFAULT now(),
+  published_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT consent_versions_type_version_uq UNIQUE (consent_type, version),
+  CONSTRAINT consent_versions_version_positive CHECK (version > 0),
+  CONSTRAINT consent_versions_document_url_not_blank
+    CHECK (length(btrim(document_url)) > 0)
+);
+
+ALTER TABLE public.consent_versions OWNER TO postgres;
+
+CREATE OR REPLACE VIEW public.current_consent_versions
+WITH (security_invoker = true) AS
+SELECT DISTINCT ON (consent_type)
+  id,
+  consent_type,
+  version,
+  document_url,
+  effective_from,
+  published_at
+FROM public.consent_versions
+WHERE effective_from <= now()
+ORDER BY consent_type, version DESC;
+
+ALTER VIEW public.current_consent_versions OWNER TO postgres;
+
+COMMENT ON VIEW public.current_consent_versions IS 'One row per consent_type: the highest version whose effective_from has passed. Query this, not consent_versions, which holds the full publication history. security_invoker, so the consent_versions SELECT policy governs access.';
+
+ALTER TABLE public.consent_versions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY consent_versions_select_policy ON public.consent_versions
+  FOR SELECT TO authenticated
+  USING (true);

--- a/supabase/migrations/20260814125300_42_seed_consent_versions_v1.sql
+++ b/supabase/migrations/20260814125300_42_seed_consent_versions_v1.sql
@@ -1,0 +1,23 @@
+-- CA-963: Publish version 1 of each consent document.
+--
+-- A migration rather than a seeder: supabase/seeders/ only runs on local
+-- `start` / `db reset`, so a seeded row would never reach production — and an
+-- empty consent_versions leaves every gate check resolving to
+-- ConsentIndeterminate, which blocks nothing but presents nothing either.
+--
+-- TODO: the document_url values below are PROVISIONAL. No published legal
+-- document URL existed when this was written; these mirror the shape the
+-- client's temporary in-memory source fakes. Confirm both against the real
+-- published documents before CONSENT_GATE_ENABLED is switched on in
+-- production. https://ripplearc.youtrack.cloud/issue/CA-963
+--
+-- ON CONFLICT DO NOTHING so a re-run against a database that already has v1
+-- (a partially applied deploy, a re-seeded branch) is a no-op rather than a
+-- unique violation that fails the whole migration.
+
+INSERT INTO public.consent_versions
+  (consent_type, version, document_url, effective_from, published_at)
+VALUES
+  ('terms_and_privacy', 1, 'https://ripplearc.com/legal/terms-and-privacy', now(), now()),
+  ('analytics',         1, 'https://ripplearc.com/legal/analytics',         now(), now())
+ON CONFLICT (consent_type, version) DO NOTHING;

--- a/supabase/schemas/_types/enums.sql
+++ b/supabase/schemas/_types/enums.sql
@@ -189,3 +189,15 @@ CREATE TYPE "public"."cost_estimation_activity_type_enum" AS ENUM (
 );
 
 ALTER TYPE "public"."cost_estimation_activity_type_enum" OWNER TO "postgres";
+
+
+-- Consent documents, versioned independently of one another. Values are the
+-- wire contract with the Flutter client (consent_wire_values.dart).
+
+CREATE TYPE "public"."consent_type_enum" AS ENUM (
+    'terms_and_privacy',
+    'analytics'
+);
+
+
+ALTER TYPE "public"."consent_type_enum" OWNER TO "postgres";

--- a/supabase/schemas/consent/consent_versions/01_table.sql
+++ b/supabase/schemas/consent/consent_versions/01_table.sql
@@ -1,0 +1,29 @@
+-- consent_versions table
+-- Published version of each consent document. Written only by migration —
+-- there is no client write path (03_rls.sql). Full publication history is
+-- kept, not current state; clients read current_consent_versions (02_views).
+-- See README.md.
+
+CREATE TABLE IF NOT EXISTS "public"."consent_versions" (
+  "id"             uuid PRIMARY KEY DEFAULT (gen_random_uuid()),
+  "consent_type"   "public"."consent_type_enum" NOT NULL,
+  "version"        integer NOT NULL,
+  "document_url"   text NOT NULL,
+  -- When this version starts binding users; distinct from published_at so a
+  -- version can be inserted ahead of time and go live on schedule.
+  "effective_from" timestamptz NOT NULL DEFAULT (now()),
+  -- Audit metadata only. Never decides the gate.
+  "published_at"   timestamptz NOT NULL DEFAULT (now()),
+
+  -- Also the access path for current_consent_versions.
+  CONSTRAINT "consent_versions_type_version_uq" UNIQUE ("consent_type", "version"),
+
+  CONSTRAINT "consent_versions_version_positive" CHECK ("version" > 0),
+
+  -- The client throws on a blank document_url and resolves the throw to a
+  -- status, not an error — so a blank would fail invisibly. Rejected on write.
+  CONSTRAINT "consent_versions_document_url_not_blank"
+    CHECK (length(btrim("document_url")) > 0)
+);
+
+ALTER TABLE "public"."consent_versions" OWNER TO "postgres";

--- a/supabase/schemas/consent/consent_versions/02_views.sql
+++ b/supabase/schemas/consent/consent_versions/02_views.sql
@@ -1,0 +1,25 @@
+-- current_consent_versions view
+-- One row per consent type: the version currently in force. This is what
+-- clients read — consent_versions holds every version ever published, so a
+-- caller selecting the base table has to pick a row itself, and the Flutter
+-- client picked an arbitrary one. See README.md.
+--
+-- security_invoker so the consent_versions SELECT policy still applies.
+-- Postgres 15+; config.toml pins major_version = 15.
+
+CREATE OR REPLACE VIEW "public"."current_consent_versions"
+WITH ("security_invoker" = true) AS
+SELECT DISTINCT ON ("consent_type")
+  "id",
+  "consent_type",
+  "version",
+  "document_url",
+  "effective_from",
+  "published_at"
+FROM "public"."consent_versions"
+WHERE "effective_from" <= "now"()
+ORDER BY "consent_type", "version" DESC;
+
+ALTER VIEW "public"."current_consent_versions" OWNER TO "postgres";
+
+COMMENT ON VIEW "public"."current_consent_versions" IS 'One row per consent_type: the highest version whose effective_from has passed. Query this, not consent_versions, which holds the full publication history. security_invoker, so the consent_versions SELECT policy governs access.';

--- a/supabase/schemas/consent/consent_versions/03_rls.sql
+++ b/supabase/schemas/consent/consent_versions/03_rls.sql
@@ -1,0 +1,12 @@
+-- RLS policies for consent_versions
+-- Read-only for clients. No INSERT/UPDATE/DELETE policy for any role: the
+-- absence is the enforcement point, since auto-expose (CA-729) grants the Data
+-- API roles full SQL access. service_role bypasses RLS, which is how the seed
+-- migration writes. Reads are unscoped — the terms are the same document for
+-- everyone. See README.md.
+
+ALTER TABLE "public"."consent_versions" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "consent_versions_select_policy" ON "public"."consent_versions"
+  FOR SELECT TO "authenticated"
+  USING (true);

--- a/supabase/schemas/consent/consent_versions/README.md
+++ b/supabase/schemas/consent/consent_versions/README.md
@@ -1,0 +1,124 @@
+# Consent Versions Module
+
+## Overview
+
+`consent_versions` records the published version of each consent document. It
+is the source of truth the app compares a user's acceptance against, introduced
+in CA-963 for the server-driven versioned consent flow (design: CA-962, parent
+epic: CA-961).
+
+The table is **publication history, not current state**: every version ever
+published stays in it. That is what keeps `user_consents` rows readable years
+later, when a record referencing version 3 of the privacy policy has to be
+interpretable against a document now on version 7. Clients therefore read the
+[`current_consent_versions`](#view-current_consent_versions) view rather than
+this table.
+
+Rows are written **only by migration**. There is no runtime write path and no
+RLS policy that would permit one.
+
+## Table Structure
+
+- `id` — UUID primary key
+- `consent_type` — `consent_type_enum` (`terms_and_privacy`, `analytics`)
+- `version` — Integer, `CHECK (version > 0)`. Monotonic per consent type
+- `document_url` — Where the user reads the document. `CHECK` rejects blank
+  values (see below)
+- `effective_from` — When this version starts binding users. Defaults to `now()`
+- `published_at` — Audit metadata: when the row was written. Never decides the
+  gate
+
+### Why `document_url` cannot be blank
+
+The Flutter client's `ConsentVersionDto.fromJson` throws a `FormatException` on
+an empty `document_url`, and `ConsentRepositoryImpl` resolves that throw to a
+*status* rather than an error — deliberately, so an unreadable requirement
+blocks instead of erroring. A blank URL would therefore produce a consent page
+with nothing to read and no visible failure anywhere. The check rejects it at
+write time instead.
+
+## Constraints
+
+- `consent_versions_type_version_uq` — `UNIQUE (consent_type, version)`. One row
+  per document version. Doubles as the access path for
+  `current_consent_versions`, which enters by `consent_type` and takes the
+  highest `version`.
+- `consent_versions_version_positive` — `CHECK (version > 0)`.
+- `consent_versions_document_url_not_blank` — `CHECK (length(btrim(document_url)) > 0)`.
+
+> **Note for the follow-up PR:** the `user_consents` log lands separately and
+> its `version` column deliberately uses `>= 0`, **not** `> 0` — a withdrawal
+> with nothing on file to revoke records version `0`. Don't copy this table's
+> check across.
+
+## View: `current_consent_versions`
+
+One row per consent type — the version currently in force:
+
+```sql
+SELECT DISTINCT ON (consent_type) …
+FROM consent_versions
+WHERE effective_from <= now()
+ORDER BY consent_type, version DESC;
+```
+
+Two rules that a caller reading the base table would have to reimplement, and
+which the Flutter client got wrong before this view existed (it took the first
+matching row, arbitrary once any document reached version 2):
+
+1. Highest `version` wins, per consent type.
+2. Rows with a future `effective_from` are not in force yet — which is what
+   makes scheduled publication possible: insert the row ahead of time and it
+   goes live on its own.
+
+Declared `WITH (security_invoker = true)` so it evaluates under the caller's
+permissions and the `consent_versions` SELECT policy still governs access.
+Postgres 15+ only; `config.toml` pins `major_version = 15`.
+
+## RLS
+
+- **SELECT** (`consent_versions_select_policy`): `USING (true)` for
+  `authenticated`. Unscoped by design — the published terms are the same
+  document for everyone, and a user cannot be asked to accept something they
+  are not allowed to read.
+- **INSERT / UPDATE / DELETE**: no policies for any client role. Publishing is a
+  migration-only act. The *absence* of policies is the enforcement point, not
+  grants: `auto_expose_new_tables` (CA-729) hands the Data API roles full
+  SQL-level access on every `db reset`, so grants deny nothing here.
+  `service_role` bypasses RLS, which is how the seed migration writes.
+
+  The three denials do **not** fail the same way, which matters when reading the
+  tests: a blocked `INSERT` raises `42501`
+  (*new row violates row-level security policy*), while a blocked `UPDATE` or
+  `DELETE` raises nothing at all — with no policy the rows are simply invisible
+  to the statement, so it reports success having changed zero rows. All three
+  are pinned in `supabase/tests/database/consent_versions_test.sql`, the write
+  paths by asserting the row is unchanged rather than by `throws_ok`.
+
+## Consumers
+
+- `RemoteConsentDataSource` (`construculator-app/lib/libraries/consent/data/data_source/remote_consent_data_source.dart`)
+  — reads `current_consent_versions` directly over the Data API, deliberately
+  bypassing local replication so a stalled sync cannot mask a newly published
+  version.
+- **CA-971** will replicate both consent tables through PowerSync for the
+  offline-first read path. Any column list added there must match the client's
+  `schema.dart` exactly.
+
+## Seeding
+
+`20260814…_42_seed_consent_versions_v1.sql` publishes version 1 of both consent
+types. It is a **migration**, not a seeder: `supabase/seeders/` only runs on
+local `start` / `db reset` and would never reach production.
+
+> **The seeded `document_url` values are provisional** — no published legal
+> document URL existed when this module was written. Confirm them before
+> `CONSENT_GATE_ENABLED` is switched on in production.
+
+## Related Tables
+
+- `user_consents` — the append-only per-user log of acceptances and
+  withdrawals, landing in the follow-up PR on this ticket. It will deliberately
+  carry **no FK** to this table: the log has to survive administrative
+  correction of the versions here, since a consent record is evidence of what a
+  user did and must not cascade away because someone fixed a document URL.

--- a/supabase/tests/database/consent_versions_test.sql
+++ b/supabase/tests/database/consent_versions_test.sql
@@ -1,0 +1,153 @@
+BEGIN;
+
+-- Tests for CA-963: consent_versions and the current_consent_versions view.
+-- Covers the enum wire contract with the Flutter client, the constraints that
+-- keep an unusable requirement out of the table, the "which version is in
+-- force" rules the view exists to own, the v1 seed, and the read-only-for-
+-- clients RLS posture.
+
+SELECT plan(14);
+
+-- ============================================================
+-- Shape
+-- ============================================================
+
+SELECT has_table('public', 'consent_versions', 'consent_versions table should exist');
+SELECT has_pk('public', 'consent_versions', 'consent_versions should have a primary key');
+
+-- Wire contract: these literals are compared against strings the Flutter
+-- client sends (consent_wire_values.dart). Renaming a value here silently
+-- stops matching on the client, so the exact set is pinned.
+SELECT is(
+  (SELECT array_to_string(array_agg(e.enumlabel ORDER BY e.enumsortorder), ',') COLLATE "C"
+     FROM pg_enum e
+     JOIN pg_type t ON t.oid = e.enumtypid
+     WHERE t.typname = 'consent_type_enum'),
+  'terms_and_privacy,analytics' COLLATE "C",
+  'consent_type_enum carries exactly the client wire values, in order'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'consent_versions_type_version_uq'
+      AND conrelid = 'public.consent_versions'::regclass
+      AND contype = 'u'
+  ),
+  'consent_versions has a UNIQUE constraint on (consent_type, version)'
+);
+
+-- ============================================================
+-- Constraints — an unusable requirement must not reach the table
+-- ============================================================
+
+SELECT throws_ok(
+  $$INSERT INTO public.consent_versions (consent_type, version, document_url)
+    VALUES ('analytics', 0, 'https://example.com/doc')$$,
+  '23514',
+  NULL,
+  'A version of 0 is rejected (versions are 1-based)'
+);
+
+-- A blank URL would present a consent page with nothing to read: the client
+-- throws on it and resolves the throw to a status rather than an error, so the
+-- failure would be invisible at runtime. Rejected on write instead.
+SELECT throws_ok(
+  $$INSERT INTO public.consent_versions (consent_type, version, document_url)
+    VALUES ('analytics', 99, '   ')$$,
+  '23514',
+  NULL,
+  'A blank document_url is rejected'
+);
+
+-- ============================================================
+-- Seed
+-- ============================================================
+
+SELECT is(
+  (SELECT count(*) FROM public.consent_versions WHERE version = 1),
+  2::bigint,
+  'The seed migration published version 1 of both consent types'
+);
+
+-- ============================================================
+-- current_consent_versions — the rules the view exists to own
+-- ============================================================
+
+DO $$
+BEGIN
+  -- v2 is live, v3 is scheduled for next week. Seeded v1 is already present.
+  INSERT INTO public.consent_versions (consent_type, version, document_url, effective_from)
+  VALUES
+    ('terms_and_privacy', 2, 'https://example.com/terms-v2', now() - interval '1 day'),
+    ('terms_and_privacy', 3, 'https://example.com/terms-v3', now() + interval '7 days');
+END $$;
+
+SELECT is(
+  (SELECT count(*) FROM public.current_consent_versions),
+  2::bigint,
+  'The view returns exactly one row per consent type'
+);
+
+SELECT is(
+  (SELECT version FROM public.current_consent_versions
+     WHERE consent_type = 'terms_and_privacy'),
+  2,
+  'The view returns the highest version whose effective_from has passed'
+);
+
+-- The whole point of effective_from: a version can be inserted ahead of time
+-- without going live. If this fails, publishing v3 early re-gates every user.
+SELECT is(
+  (SELECT count(*) FROM public.current_consent_versions
+     WHERE consent_type = 'terms_and_privacy' AND version = 3),
+  0::bigint,
+  'A version whose effective_from is still in the future is not yet in force'
+);
+
+-- ============================================================
+-- RLS — readable by any authenticated user, writable by none
+-- ============================================================
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims', '{"sub": "22222222-2222-2222-2222-222222222222"}', true);
+
+SELECT ok(
+  (SELECT count(*) FROM public.consent_versions) > 0,
+  'An authenticated user can read published consent versions'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO public.consent_versions (consent_type, version, document_url)
+    VALUES ('analytics', 42, 'https://example.com/self-published')$$,
+  '42501',
+  NULL,
+  'An authenticated client cannot publish a consent version'
+);
+
+-- UPDATE and DELETE do NOT raise. With no policy for either command the rows
+-- are simply invisible to the statement, so it succeeds having changed
+-- nothing — which is why these assert on the surviving row rather than using
+-- throws_ok. A regression that adds a permissive policy shows up as a changed
+-- URL or a missing row.
+UPDATE public.consent_versions
+  SET document_url = 'https://tampered.example'
+  WHERE consent_type = 'terms_and_privacy' AND version = 1;
+
+SELECT is(
+  (SELECT document_url FROM public.consent_versions
+     WHERE consent_type = 'terms_and_privacy' AND version = 1),
+  'https://ripplearc.com/legal/terms-and-privacy',
+  'An authenticated client cannot rewrite a published consent version'
+);
+
+DELETE FROM public.consent_versions WHERE consent_type = 'analytics';
+
+SELECT is(
+  (SELECT count(*) FROM public.consent_versions WHERE consent_type = 'analytics'),
+  1::bigint,
+  'An authenticated client cannot retract a published consent version'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Adds `consent_versions` (publication history of each consent document) and `current_consent_versions` (highest live version per type, respecting `effective_from`)
- Read-only for clients via the view — SELECT-only RLS, no write policy for any role, so publishing stays a migration-only act
- Seeds version 1 of both consent types with provisional document URLs (must be confirmed before `CONSENT_GATE_ENABLED` goes live)

## Stack
1. **This PR** — `consent_versions` schema + seed
2. #next — `user_consents` append-only log (stacked on this branch)

## Test plan
- [x] `supabase/tests/database/consent_versions_test.sql` covers RLS read-only behavior, blank `document_url` rejection, and `current_consent_versions` selection logic
- [x] `npx supabase db reset` locally to confirm migration applies cleanly