### PR TITLE
CA-963: feat(consent): add the append-only user_consents log

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ npx supabase test db
 | `cascade_delete_test` | Soft-delete cascade behavior |
 | `check_email_exists_test` | Email lookup RPC function |
 | `consent_versions_test` | Consent version constraints, the `current_consent_versions` view's in-force rules, and read-only RLS |
+| `user_consents_test` | Append-only consent log: the deliberately absent constraints, `version >= 0` for withdrawals, and own-rows-only RLS |
 
 > Tests are **required to pass** on every PR — CI will block merge on failure.
 

--- a/supabase/migrations/20260814190000_43_user_consents.sql
+++ b/supabase/migrations/20260814190000_43_user_consents.sql
@@ -1,0 +1,64 @@
+-- CA-963: Add user_consents — the append-only log of consent decisions,
+-- withdrawals as well as acceptances. Completes the consent schema begun in
+-- migration 41 (consent_versions).
+--
+-- Adds consent_action_enum and the jwt_internal_user_id() RLS helper, which
+-- exists because auth.uid() returns users.credential_id while user_consents.
+-- user_id references users.id — a policy on auth.uid() matches nothing and the
+-- symptom looks like broken sync rather than a bug.
+--
+-- Written by hand rather than via `supabase db diff`: config.toml declares
+-- schema_paths = [], so the CLI has no declared schema to diff against.
+-- Mirrors supabase/schemas/consent/user_consents/ and the shared helper in
+-- supabase/schemas/_shared/01_functions.sql — keep them in step.
+-- https://ripplearc.youtrack.cloud/issue/CA-963
+
+CREATE TYPE public.consent_action_enum AS ENUM (
+  'accepted',
+  'withdrawn'
+);
+
+ALTER TYPE public.consent_action_enum OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.jwt_internal_user_id()
+RETURNS uuid
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+AS $$
+  SELECT NULLIF(auth.jwt() -> 'app_metadata' ->> 'internal_user_id', '')::uuid
+$$;
+
+ALTER FUNCTION public.jwt_internal_user_id() OWNER TO postgres;
+
+COMMENT ON FUNCTION public.jwt_internal_user_id() IS 'Shared RLS helper. Returns the caller''s public.users.id from the JWT app_metadata.internal_user_id claim, or NULL when the claim is absent. Use instead of auth.uid() on tables keyed by users.id -- auth.uid() resolves to users.credential_id and never matches. NULL never equals a NOT NULL user_id, so an absent claim denies rather than leaks.';
+
+CREATE TABLE IF NOT EXISTS public.user_consents (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  consent_type public.consent_type_enum NOT NULL,
+  version      integer NOT NULL,
+  action       public.consent_action_enum NOT NULL,
+  recorded_at  timestamptz NOT NULL DEFAULT now(),
+  app_version  text,
+  platform     text,
+  -- >= 0, not > 0: a withdrawal with nothing on file to revoke records 0.
+  CONSTRAINT user_consents_version_non_negative CHECK (version >= 0)
+);
+
+ALTER TABLE public.user_consents OWNER TO postgres;
+
+CREATE INDEX IF NOT EXISTS user_consents_user_type_recorded_idx
+  ON public.user_consents (user_id, consent_type, recorded_at DESC);
+
+ALTER TABLE public.user_consents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_consents_select_policy ON public.user_consents
+  FOR SELECT TO authenticated
+  USING (user_id = public.jwt_internal_user_id());
+
+CREATE POLICY user_consents_insert_policy ON public.user_consents
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = public.jwt_internal_user_id());
+
+-- No UPDATE or DELETE policy, deliberately: the log is append-only.

--- a/supabase/schemas/_shared/01_functions.sql
+++ b/supabase/schemas/_shared/01_functions.sql
@@ -13,3 +13,21 @@ $$;
 
 ALTER FUNCTION "public"."set_current_timestamp_updated_at"() OWNER TO "postgres";
 COMMENT ON FUNCTION "public"."set_current_timestamp_updated_at"() IS 'Shared trigger function. Sets updated_at to now() on any BEFORE UPDATE trigger. Safe for use across all tables with an updated_at column.';
+
+
+-- RLS helper: the caller's internal users.id, from the JWT.
+--
+-- auth.uid() returns users.credential_id, so a policy on a table keyed by
+-- users.id silently matches nothing. custom_access_token_hook already puts the
+-- right id on the token, so no users lookup is needed.
+CREATE OR REPLACE FUNCTION "public"."jwt_internal_user_id"()
+    RETURNS "uuid"
+    LANGUAGE "sql"
+    SECURITY INVOKER
+    STABLE
+    AS $$
+  SELECT NULLIF("auth"."jwt"() -> 'app_metadata' ->> 'internal_user_id', '')::"uuid"
+$$;
+
+ALTER FUNCTION "public"."jwt_internal_user_id"() OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."jwt_internal_user_id"() IS 'Shared RLS helper. Returns the caller''s public.users.id from the JWT app_metadata.internal_user_id claim, or NULL when the claim is absent. Use instead of auth.uid() on tables keyed by users.id -- auth.uid() resolves to users.credential_id and never matches. NULL never equals a NOT NULL user_id, so an absent claim denies rather than leaks.';

--- a/supabase/schemas/_types/enums.sql
+++ b/supabase/schemas/_types/enums.sql
@@ -201,3 +201,16 @@ CREATE TYPE "public"."consent_type_enum" AS ENUM (
 
 
 ALTER TYPE "public"."consent_type_enum" OWNER TO "postgres";
+
+
+-- What a single user_consents row states. Withdrawing appends a 'withdrawn'
+-- row rather than deleting the acceptance, so the log separates consent that
+-- was revoked from consent never given.
+
+CREATE TYPE "public"."consent_action_enum" AS ENUM (
+    'accepted',
+    'withdrawn'
+);
+
+
+ALTER TYPE "public"."consent_action_enum" OWNER TO "postgres";

--- a/supabase/schemas/consent/user_consents/01_table.sql
+++ b/supabase/schemas/consent/user_consents/01_table.sql
@@ -1,0 +1,34 @@
+-- user_consents table
+-- Append-only log of every consent decision — withdrawals as well as
+-- acceptances. Only the newest row per (user_id, consent_type) is meaningful
+-- to the gate; everything beneath it is history. No IP or user agent: CA-962
+-- specifies app_version and platform as the only context captured.
+-- See README.md.
+
+CREATE TABLE IF NOT EXISTS "public"."user_consents" (
+  "id"           uuid PRIMARY KEY DEFAULT (gen_random_uuid()),
+  "user_id"      uuid NOT NULL
+                   REFERENCES "public"."users"("id") ON DELETE CASCADE,
+  "consent_type" "public"."consent_type_enum" NOT NULL,
+  "version"      integer NOT NULL,
+  "action"       "public"."consent_action_enum" NOT NULL,
+  "recorded_at"  timestamptz NOT NULL DEFAULT (now()),
+  "app_version"  text,
+  "platform"     text,
+
+  -- NOT `> 0`, unlike consent_versions.version. A withdrawal records the
+  -- version it revokes, and the client writes 0 when there is nothing on file
+  -- to revoke; `> 0` would reject exactly those withdrawals at runtime.
+  CONSTRAINT "user_consents_version_non_negative" CHECK ("version" >= 0)
+);
+
+ALTER TABLE "public"."user_consents" OWNER TO "postgres";
+
+-- Two constraints deliberately ABSENT, both of which look like reasonable
+-- review suggestions:
+--   * No FK to consent_versions — the log must survive administrative
+--     correction of that table; a consent record is evidence and must not
+--     cascade away because someone fixed a document URL.
+--   * No UNIQUE on (user_id, consent_type, version) — accept, withdraw, then
+--     accept the same version again is legitimate, and all three are real
+--     events.

--- a/supabase/schemas/consent/user_consents/02_indexes.sql
+++ b/supabase/schemas/consent/user_consents/02_indexes.sql
@@ -1,0 +1,8 @@
+-- Indexes for user_consents
+
+-- The only query the gate runs: newest record for one user and one consent
+-- type. Equality on the first two columns, recorded_at DESC supplying the
+-- order, so the newest row is read first with no sort.
+-- Not UNIQUE — see 01_table.sql.
+CREATE INDEX IF NOT EXISTS "user_consents_user_type_recorded_idx"
+  ON "public"."user_consents" ("user_id", "consent_type", "recorded_at" DESC);

--- a/supabase/schemas/consent/user_consents/03_rls.sql
+++ b/supabase/schemas/consent/user_consents/03_rls.sql
@@ -1,0 +1,20 @@
+-- RLS policies for user_consents
+-- Personal ownership on read and insert; no update or delete path for anyone,
+-- which is what makes the table append-only. Withdrawal is an INSERT of a
+-- 'withdrawn' row, never an UPDATE of the acceptance it supersedes.
+--
+-- Keyed on jwt_internal_user_id(), NOT auth.uid(): auth.uid() returns
+-- users.credential_id while user_id here references users.id, so auth.uid()
+-- would match nothing and read as "consent isn't syncing" rather than as a bug.
+-- See README.md.
+
+ALTER TABLE "public"."user_consents" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_consents_select_policy" ON "public"."user_consents"
+  FOR SELECT TO "authenticated"
+  USING ("user_id" = "public"."jwt_internal_user_id"());
+
+-- WITH CHECK is what stops a user recording consent in someone else's name.
+CREATE POLICY "user_consents_insert_policy" ON "public"."user_consents"
+  FOR INSERT TO "authenticated"
+  WITH CHECK ("user_id" = "public"."jwt_internal_user_id"());

--- a/supabase/schemas/consent/user_consents/README.md
+++ b/supabase/schemas/consent/user_consents/README.md
@@ -1,0 +1,102 @@
+# User Consents Module
+
+## Overview
+
+`user_consents` is the append-only log of every consent decision a user has
+made — **acceptances and withdrawals alike**, not just acceptances. Introduced
+in CA-963 for the server-driven versioned consent flow (design: CA-962, parent
+epic: CA-961).
+
+Append-only is the design, not an implementation detail. Withdrawing consent
+inserts a `withdrawn` row rather than deleting the `accepted` one, so the trail
+separates *consented, then revoked* from *never consented* — a distinction that
+matters to anyone auditing what a user agreed to and when. Only the newest row
+per `(user_id, consent_type)` is meaningful to the gate; everything beneath it
+is history.
+
+## Table Structure
+
+- `id` — UUID primary key. Assigned on insert; the client's
+  `UserConsentDto.toInsertJson()` omits it
+- `user_id` — FK to `users.id`, `ON DELETE CASCADE`
+- `consent_type` — `consent_type_enum` (`terms_and_privacy`, `analytics`)
+- `version` — Integer, `CHECK (version >= 0)`. The document version this record
+  refers to
+- `action` — `consent_action_enum` (`accepted`, `withdrawn`)
+- `recorded_at` — When the user took the action
+- `app_version` — Nullable audit metadata
+- `platform` — Nullable audit metadata
+
+No IP address and no user agent. CA-962 specifies `app_version` and `platform`
+as the only context captured, and the table holds no PII beyond the user
+reference itself.
+
+### Why `version >= 0` and not `> 0`
+
+`consent_versions.version` is `CHECK (version > 0)` and it is tempting to
+mirror that here. **Don't.** A withdrawal records the version it revokes, and
+`ConsentRepositoryImpl.recordWithdrawal` writes `0` when there is nothing on
+file to revoke (`_effectiveAcceptedVersion(current) ?? 0`). A `> 0` check would
+reject exactly those withdrawals, at runtime, on the path where a user is
+trying to revoke consent.
+
+## Indexes
+
+- `user_consents_user_type_recorded_idx` —
+  `(user_id, consent_type, recorded_at DESC)`. Matches the only query the gate
+  runs: newest record for one user and one consent type. Equality on the first
+  two columns, `recorded_at DESC` supplying the order, so the newest row is
+  read first with no sort.
+
+## Deliberately Absent Constraints
+
+Both of these look like reasonable review suggestions. Neither is correct:
+
+- **No FK on `(consent_type, version)` to `consent_versions`.** The log must
+  survive administrative correction of the versions table. A consent record is
+  evidence of what a user did; it cannot become un-writable — or cascade away —
+  because someone fixed a typo in a document URL upstream.
+- **No `UNIQUE (user_id, consent_type, version)`.** A user may accept version 2,
+  withdraw it, and accept version 2 again. All three are real events and all
+  three belong in the log.
+
+## RLS
+
+Keyed on `public.jwt_internal_user_id()`, **not** `auth.uid()`. `auth.uid()`
+returns `users.credential_id` while `user_id` here references `users.id` — the
+two never match, so policies written against `auth.uid()` return zero rows for
+every user, and the symptom reads like "consent isn't syncing" rather than like
+a bug. The helper lives in `schemas/_shared/01_functions.sql`.
+
+- **SELECT** (`user_consents_select_policy`): `user_id = jwt_internal_user_id()`.
+  Personal ownership; no cross-user or admin visibility.
+- **INSERT** (`user_consents_insert_policy`): same predicate as `WITH CHECK` —
+  this is what stops a user recording consent in someone else's name.
+- **UPDATE / DELETE**: no policies, for any role, *including the row's owner*.
+  This is what makes the table append-only. The absence is the enforcement
+  point, not grants: `auto_expose_new_tables` (CA-729) gives the Data API roles
+  full SQL-level access on every `db reset`, so RLS is the only thing between a
+  client and a rewritten consent history.
+
+  The denials do **not** fail alike, which matters when reading the tests: a
+  blocked `INSERT` raises `42501`, while a blocked `UPDATE` or `DELETE` raises
+  nothing — with no policy the rows are invisible to the statement, so it
+  reports success having changed zero rows. All are pinned in
+  `supabase/tests/database/user_consents_test.sql`, the write paths by
+  asserting the row survives unchanged rather than by `throws_ok`.
+
+## Consumers
+
+- `ConsentRepositoryImpl` (`construculator-app/lib/libraries/consent/data/repositories/consent_repository_impl.dart`)
+  — writes one row per accept and per withdraw, and reads the newest row to
+  decide the gate.
+- **CA-971** replaces the app's temporary `InMemoryConsentDataSource` with a
+  PowerSync-backed local store reading this table, and adds the sync stream
+  filtered to `auth.parameter('$.app_metadata.internal_user_id')`.
+
+## Related Tables
+
+- `consent_versions` — published document versions, and the
+  `current_consent_versions` view the gate compares against. No FK links the
+  two; see above.
+- `users` — `user_id` references `users.id`; user deletion cascades here.

--- a/supabase/tests/database/user_consents_test.sql
+++ b/supabase/tests/database/user_consents_test.sql
@@ -1,0 +1,152 @@
+BEGIN;
+
+-- Tests for CA-963: user_consents, the append-only log of consent decisions.
+-- Covers the action enum wire contract, the constraints that must NOT exist
+-- (an FK to consent_versions, a uniqueness rule on re-acceptance), the
+-- version >= 0 allowance that withdrawals depend on, and the RLS posture:
+-- own rows only, keyed on the internal_user_id JWT claim rather than
+-- auth.uid(), with no update or delete path for anyone.
+
+SELECT plan(13);
+
+-- ============================================================
+-- Shape
+-- ============================================================
+
+SELECT has_table('public', 'user_consents', 'user_consents table should exist');
+SELECT has_pk('public', 'user_consents', 'user_consents should have a primary key');
+SELECT col_is_fk('public', 'user_consents', 'user_id', 'user_consents.user_id is a FK to users');
+
+SELECT is(
+  (SELECT array_to_string(array_agg(e.enumlabel ORDER BY e.enumsortorder), ',') COLLATE "C"
+     FROM pg_enum e
+     JOIN pg_type t ON t.oid = e.enumtypid
+     WHERE t.typname = 'consent_action_enum'),
+  'accepted,withdrawn' COLLATE "C",
+  'consent_action_enum carries exactly the client wire values, in order'
+);
+
+SELECT has_index(
+  'public', 'user_consents', 'user_consents_user_type_recorded_idx',
+  'The (user_id, consent_type, recorded_at) lookup index exists'
+);
+
+-- ============================================================
+-- Constraints that must NOT exist
+--
+-- Both would look like reasonable review additions, and both would break a
+-- real path — so their absence is asserted rather than left to comments.
+-- ============================================================
+
+SELECT is(
+  (SELECT count(*) FROM pg_constraint
+     WHERE conrelid = 'public.user_consents'::regclass
+       AND contype = 'f'
+       AND confrelid = 'public.consent_versions'::regclass),
+  0::bigint,
+  'user_consents has NO foreign key to consent_versions (log survives corrections there)'
+);
+
+SELECT is(
+  (SELECT count(*) FROM pg_constraint
+     WHERE conrelid = 'public.user_consents'::regclass
+       AND contype = 'u'),
+  0::bigint,
+  'user_consents has NO unique constraint (re-accepting after a withdrawal is legitimate)'
+);
+
+-- ============================================================
+-- Fixtures
+-- ============================================================
+
+DO $$
+DECLARE
+  v_role_id uuid := '55555555-5555-5555-5555-555555555555';
+BEGIN
+  INSERT INTO professional_roles (id, name) VALUES (v_role_id, 'Consent Test Role');
+
+  INSERT INTO users (id, credential_id, email, first_name, last_name, professional_role, created_at, user_status, user_preferences, country_code)
+  VALUES
+    ('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222',
+     'consent_owner@example.com', 'Consent', 'Owner', v_role_id, now(), 'active', '{}', '+1'),
+    ('33333333-3333-3333-3333-333333333333', '44444444-4444-4444-4444-444444444444',
+     'consent_other@example.com', 'Consent', 'Other', v_role_id, now(), 'active', '{}', '+1');
+
+  -- The other user's record: must never be visible to the owner below.
+  INSERT INTO user_consents (user_id, consent_type, version, action)
+  VALUES ('33333333-3333-3333-3333-333333333333', 'terms_and_privacy', 1, 'accepted');
+END $$;
+
+-- A full accept -> withdraw -> re-accept cycle on ONE version. This is the
+-- sequence a UNIQUE (user_id, consent_type, version) would break, and the
+-- withdrawal-with-nothing-on-file case is what version >= 0 exists for.
+SELECT lives_ok(
+  $$INSERT INTO public.user_consents (user_id, consent_type, version, action) VALUES
+      ('11111111-1111-1111-1111-111111111111', 'terms_and_privacy', 0, 'withdrawn'),
+      ('11111111-1111-1111-1111-111111111111', 'terms_and_privacy', 2, 'accepted'),
+      ('11111111-1111-1111-1111-111111111111', 'terms_and_privacy', 2, 'withdrawn'),
+      ('11111111-1111-1111-1111-111111111111', 'terms_and_privacy', 2, 'accepted')$$,
+  'A withdrawal at version 0 and a re-accept of the same version both insert cleanly'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO public.user_consents (user_id, consent_type, version, action)
+    VALUES ('11111111-1111-1111-1111-111111111111', 'analytics', -1, 'accepted')$$,
+  '23514',
+  NULL,
+  'A negative version is still rejected'
+);
+
+-- ============================================================
+-- RLS — own rows only, via the internal_user_id claim
+-- ============================================================
+
+SET LOCAL ROLE authenticated;
+
+-- Note the claim shape: app_metadata.internal_user_id is users.id, NOT the
+-- sub/credential_id. A policy written against auth.uid() would compare
+-- credential_id to user_id and match nothing.
+SELECT set_config('request.jwt.claims', '{
+  "sub": "22222222-2222-2222-2222-222222222222",
+  "app_metadata": { "internal_user_id": "11111111-1111-1111-1111-111111111111" }
+}', true);
+
+SELECT is(
+  (SELECT count(*) FROM public.user_consents),
+  4::bigint,
+  'A user sees their own consent records and only those'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO public.user_consents (user_id, consent_type, version, action)
+    VALUES ('33333333-3333-3333-3333-333333333333', 'analytics', 1, 'accepted')$$,
+  '42501',
+  NULL,
+  'A user cannot record consent in someone else''s name'
+);
+
+-- UPDATE and DELETE raise nothing: with no policy the rows are invisible to
+-- the statement, which succeeds having changed zero rows. Asserted on the
+-- surviving data rather than with throws_ok, so a permissive policy added
+-- later shows up as a mutated or missing row.
+UPDATE public.user_consents SET action = 'accepted'
+  WHERE user_id = '11111111-1111-1111-1111-111111111111' AND action = 'withdrawn';
+
+SELECT is(
+  (SELECT count(*) FROM public.user_consents
+     WHERE user_id = '11111111-1111-1111-1111-111111111111' AND action = 'withdrawn'),
+  2::bigint,
+  'A user cannot rewrite their consent history (append-only)'
+);
+
+DELETE FROM public.user_consents WHERE user_id = '11111111-1111-1111-1111-111111111111';
+
+SELECT is(
+  (SELECT count(*) FROM public.user_consents
+     WHERE user_id = '11111111-1111-1111-1111-111111111111'),
+  4::bigint,
+  'A user cannot delete their consent history (append-only)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Adds `user_consents`, an append-only log of every consent decision (acceptances and withdrawals) keyed by `jwt_internal_user_id()` rather than `auth.uid()`, since `auth.uid()` resolves to `credential_id`, not `users.id`
- No UPDATE/DELETE policy for anyone, including the row owner — that's what makes the log append-only
- Deliberately no FK to `consent_versions` and no uniqueness on `(user_id, consent_type, version)` — see commit message for rationale

## Stack
- Based on #48 (`consent_versions` schema) — merge that first, then rebase this onto `master`

## Test plan
- [x] `supabase/tests/database/user_consents_test.sql` covers RLS append-only semantics (blocked UPDATE/DELETE return zero rows, not errors) and withdrawal-without-prior-acceptance (`version = 0`)
- [x] `npx supabase db reset` locally to confirm migration applies cleanly on top of #48