### PR TITLE
CA-749: seed the auth credential for the sample user

### DIFF
--- a/supabase/seeders/sample_data/100_auth_users.sql
+++ b/supabase/seeders/sample_data/100_auth_users.sql
@@ -1,0 +1,69 @@
+-- Auth Users Seeder
+-- Creates the GoTrue account backing the seeded public.users row in
+-- 103_users.sql. public.users.credential_id points at auth.users.id, but no
+-- foreign key enforces it, so without this file the seeded user can be read
+-- from the database yet can never sign in. E2E sign-in flows depend on it.
+--
+-- Runs before 103_users.sql so the credential exists before it is referenced.
+
+-- The seeded password is a fixed, well-known value. It is only ever valid
+-- against a local Docker Supabase stack started from this repository, which is
+-- never exposed outside the developer machine or the CI runner. Never reuse it
+-- for a hosted environment.
+INSERT INTO auth.users (
+  "instance_id",
+  "id",
+  "aud",
+  "role",
+  "email",
+  "encrypted_password",
+  "email_confirmed_at",
+  "raw_app_meta_data",
+  "raw_user_meta_data",
+  "created_at",
+  "updated_at",
+  "confirmation_token",
+  "recovery_token",
+  "email_change_token_new",
+  "email_change"
+) VALUES
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '850e8400-e29b-41d4-a716-446655440000',
+    'authenticated',
+    'authenticated',
+    'seeder@example.com',
+    extensions.crypt('e2e-local-only-password', extensions.gen_salt('bf')),
+    now(),
+    '{"provider": "email", "providers": ["email"]}',
+    '{}',
+    now(),
+    now(),
+    '',
+    '',
+    '',
+    ''
+  )
+ON CONFLICT ("id") DO NOTHING;
+
+-- GoTrue resolves the email/password grant through auth.identities, so the
+-- account is not usable without a matching email identity.
+INSERT INTO auth.identities (
+  "provider_id",
+  "user_id",
+  "identity_data",
+  "provider",
+  "last_sign_in_at",
+  "created_at",
+  "updated_at"
+) VALUES
+  (
+    '850e8400-e29b-41d4-a716-446655440000',
+    '850e8400-e29b-41d4-a716-446655440000',
+    '{"sub": "850e8400-e29b-41d4-a716-446655440000", "email": "seeder@example.com", "email_verified": true, "phone_verified": false}',
+    'email',
+    now(),
+    now(),
+    now()
+  )
+ON CONFLICT ("provider_id", "provider") DO NOTHING;

--- a/supabase/tests/database/seeded_auth_user_test.sql
+++ b/supabase/tests/database/seeded_auth_user_test.sql
@@ -1,0 +1,41 @@
+begin;
+select plan(5);
+
+-- The seeded public.users row is unusable for sign-in unless a matching GoTrue
+-- credential exists, which is what these assertions guard.
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM auth.users WHERE "email" = 'seeder@example.com'),
+  'seeded auth user should exist'
+);
+
+SELECT is(
+  (SELECT "credential_id" FROM public.users WHERE "email" = 'seeder@example.com'),
+  (SELECT "id" FROM auth.users WHERE "email" = 'seeder@example.com'),
+  'public.users.credential_id should match the seeded auth user id'
+);
+
+SELECT ok(
+  (SELECT "email_confirmed_at" IS NOT NULL FROM auth.users WHERE "email" = 'seeder@example.com'),
+  'seeded auth user should have a confirmed email'
+);
+
+SELECT ok(
+  (
+    SELECT "encrypted_password" = extensions.crypt('e2e-local-only-password', "encrypted_password")
+    FROM auth.users WHERE "email" = 'seeder@example.com'
+  ),
+  'seeded auth user password should verify against the documented seed password'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM auth.identities i
+    JOIN auth.users u ON u."id" = i."user_id"
+    WHERE u."email" = 'seeder@example.com' AND i."provider" = 'email'
+  ),
+  'seeded auth user should have an email identity'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
### 1. PR SUMMARY


The sample data seeded a `public.users` row for `seeder@example.com` whose
`credential_id` referenced an `auth.users` id that was never created, and no
foreign key caught the dangling reference. The account could be read from the
database but could never sign in, so end-to-end sign-in journeys had no usable
user. This seeds the matching GoTrue credential and its email identity, and adds
a pgTAP test that fails if the link breaks again.

**Type:** Feature ·
**Size:** S (69 seeder lines, 54 of them statements; 41 test lines excluded) ·
**Rules applied:** Digestible PR

> **Sizing note:** the rule's detection pattern counts only `lib/**/*.dart`, which is zero here — that would report XS and understate the change. The sizes below are the branch's actual reviewable lines (tests and generated files excluded).

### What changed
- `supabase/seeders/sample_data/100_auth_users.sql` — the `auth.users` credential and its `auth.identities` row, numbered to load before `103_users.sql`.
- `supabase/tests/database/seeded_auth_user_test.sql` — 5 assertions covering existence, the `credential_id` link, email confirmation, password verification and the email identity.

### 2. REVIEW SUMMARY TABLE


> Found 2 issue(s): 0 🔴 critical · 0 🟠 major · 0 🟡 minor · 2 🔵 suggestion — across 1 file(s).

| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
|---|-------|----------|----------|-------------|---------------|--------|-------|
| 1 | Signable account reaches every local database | 🔵 Suggestion | `supabase/seeders/sample_data/100_auth_users.sql:1` | Placing this in shared `sample_data/` means local development and `database_tests.yml` also get an account with a published password, not just the E2E stack. | Accepted by design — one seeded fixture shared by all three consumers is the point, and the credential is only ever valid against a local Docker stack. The password comment states that constraint explicitly. | ❌ Disagree | Approved placement; splitting it into an E2E-only seed would let the two drift. |
| 2 | Verification depended on unstated schema assumptions | 🔵 Suggestion | `supabase/seeders/sample_data/100_auth_users.sql:50` | `auth.identities` gained `provider_id` in a GoTrue schema change, and `crypt`/`gen_salt` live in the `extensions` schema rather than `public` — either assumption being wrong would fail the seed at load time. | Verified on an isolated stack: the seeders loaded in order and the full suite passed (19 files, 197 tests). | ✅ Addressed | |

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

## Test plan

Verified on an **isolated** Supabase stack (`project_id = "ca749probe"`, ports 556xx) built from a copy of this repo's config — never against a developer's real local stack.

- Seeders load in the intended order: `100_auth_users.sql` runs before `103_users.sql`.
- `auth.users` row exists, email is confirmed, and the password verifies via `extensions.crypt`.
- `auth.identities` email identity present; `public.users.credential_id` equals `auth.users.id`.
- Full pgTAP suite: `Files=19, Tests=197 ... Result: PASS`, including the new `seeded_auth_user_test.sql`, with no existing test regressed.
- Seeds are idempotent across `supabase db reset` — the password still verifies afterwards.
