### PR TITLE
CA-991: isolate the E2E project_id from ordinary local dev

### DIFF
--- a/powersync/.env.example
+++ b/powersync/.env.example
@@ -5,5 +5,5 @@
 PS_API_TOKEN=your-secure-api-token-here
 
 PS_PORT=8081
-PS_POSTGRES_URI=postgresql://postgres:postgres@supabase_db_construculator-backend:5432/postgres
-PS_JWKS_URI=http://supabase_kong_construculator-backend:8000/auth/v1/.well-known/jwks.json
+PS_POSTGRES_URI=postgresql://postgres:postgres@supabase_db_construculator-backend-e2e:5432/postgres
+PS_JWKS_URI=http://supabase_kong_construculator-backend-e2e:8000/auth/v1/.well-known/jwks.json

--- a/powersync/README.md
+++ b/powersync/README.md
@@ -34,13 +34,13 @@ docker compose up -d
 ### 4. Verify Connection
 ```bash
 # Check replication is active
-docker exec supabase_db_construculator-backend psql -U postgres -c \
+docker exec supabase_db_construculator-backend-e2e psql -U postgres -c \
   "SELECT slot_name, active FROM pg_replication_slots WHERE slot_name LIKE 'powersync%';"
 
 # Should show: active = t
 
 # Test data sync
-docker exec supabase_db_construculator-backend psql -U postgres -d postgres -c \
+docker exec supabase_db_construculator-backend-e2e psql -U postgres -d postgres -c \
   "INSERT INTO professional_roles (name) VALUES ('Test Role') RETURNING *;"
 
 # Check PowerSync processed it
@@ -56,8 +56,8 @@ All variables are required in `.env`:
 |----------|-------------|---------|
 | `PS_API_TOKEN`| API authentication token | Generate: `openssl rand -hex 32` |
 | `PS_PORT` | PowerSync service port | `8081` |
-| `PS_POSTGRES_URI` | PostgreSQL connection string | `postgresql://postgres:postgres@supabase_db_construculator-backend:5432/postgres` |
-| `PS_JWKS_URI`  | Supabase Auth JWKS endpoint | `http://supabase_kong_construculator-backend:8000/auth/v1/.well-known/jwks.json` |
+| `PS_POSTGRES_URI` | PostgreSQL connection string | `postgresql://postgres:postgres@supabase_db_construculator-backend-e2e:5432/postgres` |
+| `PS_JWKS_URI`  | Supabase Auth JWKS endpoint | `http://supabase_kong_construculator-backend-e2e:8000/auth/v1/.well-known/jwks.json` |
 
 ### Local Development
 
@@ -177,11 +177,11 @@ docker compose logs powersync
 **No data syncing:**
 ```bash
 # 1. Check replication slot is active
-docker exec supabase_db_construculator-backend psql -U postgres -c \
+docker exec supabase_db_construculator-backend-e2e psql -U postgres -c \
   "SELECT slot_name, active FROM pg_replication_slots WHERE slot_name LIKE 'powersync%';"
 
 # 2. Verify table is in publication
-docker exec supabase_db_construculator-backend psql -U postgres -c \
+docker exec supabase_db_construculator-backend-e2e psql -U postgres -c \
   "SELECT tablename FROM pg_publication_tables WHERE pubname = 'powersync';"
 
 # 3. Check table is in sync rules (sync-config.yaml)

--- a/powersync/compose.yaml
+++ b/powersync/compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - mongo_storage:/data/db
     networks:
-      - supabase_network_construculator-backend
+      - supabase_network_construculator-backend-e2e
 
   # Initialize MongoDB replica set
   mongo-rs-init:
@@ -24,7 +24,7 @@ services:
         {} rs.initiate({_id: \"rs0\", version: 1, members: [{ _id: 0, host :
         \"mongo:27017\" }]})'"
     networks:
-      - supabase_network_construculator-backend
+      - supabase_network_construculator-backend-e2e
 
   powersync:
     image: journeyapps/powersync-service:1.20.5
@@ -43,7 +43,7 @@ services:
       POWERSYNC_CONFIG_PATH: /config/service.yaml
       PS_MONGO_URI: mongodb://mongo:27017/powersync
     networks:
-      - supabase_network_construculator-backend
+      - supabase_network_construculator-backend-e2e
     restart: unless-stopped
     healthcheck:
       test:
@@ -58,9 +58,9 @@ services:
       retries: 5
 
 networks:
-  supabase_network_construculator-backend:
+  supabase_network_construculator-backend-e2e:
     external: true
-    name: supabase_network_construculator-backend
+    name: supabase_network_construculator-backend-e2e
 
 volumes:
   mongo_storage:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "construculator-backend"
+project_id = "construculator-backend-e2e"
 
 [api]
 enabled = true

--- a/supabase/schemas/global_search/global_search/README.md
+++ b/supabase/schemas/global_search/global_search/README.md
@@ -49,7 +49,7 @@ supabase db reset
 
 # 2) Apply this module's schemas to the running local DB.
 for f in supabase/schemas/global_search/global_search/0?_*.sql; do
-  docker exec -i supabase_db_construculator-backend \
+  docker exec -i supabase_db_construculator-backend-e2e \
     psql -U postgres -d postgres -v ON_ERROR_STOP=1 < "$f"
 done
 

--- a/supabase/schemas/global_search/project_search_history/README.md
+++ b/supabase/schemas/global_search/project_search_history/README.md
@@ -129,7 +129,7 @@ supabase db reset
 
 # 2) Apply this module's schemas to the running local DB.
 for f in supabase/schemas/global_search/project_search_history/0?_*.sql; do
-  docker exec -i supabase_db_construculator-backend \
+  docker exec -i supabase_db_construculator-backend-e2e \
     psql -U postgres -d postgres -v ON_ERROR_STOP=1 < "$f"
 done
 


### PR DESCRIPTION
## Summary
- Renames the local Supabase `project_id` from `construculator-backend` to `construculator-backend-e2e` in `supabase/config.toml`, so the containers, volumes and Docker network it creates are distinct from whatever project_id a developer's own local Supabase work defaults to.
- Updates the hardcoded network/host names derived from that project_id in `powersync/compose.yaml` (the `external: true` network reference) and `powersync/.env.example` (`PS_POSTGRES_URI`, `PS_JWKS_URI`).
- Updates the `docker exec supabase_db_...` examples in `powersync/README.md` and the two `global_search` schema READMEs so they keep working against the renamed container.

## Context
CA-749 (in `construculator-app`) stood up scripts that start/stop/reset this stack for E2E tests, assuming it was already isolated. Independent review found it wasn't: `project_id = "construculator-backend"` collided with whatever a developer's own local Supabase project defaults to from the same directory name, so `reset_env.sh` / `stop_env.sh --purge` could destroy real local dev data. Companion PR in `construculator-app`: https://github.com/ripplearc/construculator-app/pull/576 (points the app-side scripts at the renamed `construculator-backend-e2e` project).

## Test plan
- [x] `docker compose config` parity check (parsed `powersync/compose.yaml` via PyYAML) — no syntax errors, single `supabase_network_construculator-backend-e2e` network defined and referenced consistently.
- [ ] Manual: `supabase start` + `docker compose -f powersync/compose.yaml up -d` and confirm containers/network are named `..._construculator-backend-e2e`.

https://claude.ai/code/session_015gw6KVFcjiZ39MHNwcFAco